### PR TITLE
Fix building scenario for Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 project (clickhouse-odbc)
 cmake_minimum_required (VERSION 2.6)
+cmake_policy(SET CMP0042 OLD)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${clickhouse-odbc_SOURCE_DIR}/cmake/Modules")
 
 include(GNUInstallDirs)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(clickhouse-odbc
     ${Poco_Net_LIBRARY}
     ${Poco_Foundation_LIBRARY}
     ${ODBC_LIBRARIES}
-    -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/linker_script
+    "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/linker_script"
 )
 
 if(APPLE)


### PR DESCRIPTION
My colleagues have some obstacles to build `libclickhouseodbc.dylib`. Here is fix for that issues.