### PR TITLE
Testing driver on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,11 @@ install:
   # Need in binulils because /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
 
+before_script:
+  # nanodbc for more tests
+  - cd /contrib; git clone https://github.com/nanodbc/nanodbc; cd ..
+  - ls -lah . ./contrib
+
 script:
   - mkdir -p build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,13 +118,6 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get update -q > build.log 2>&1 || (cat build.log && exit 1); fi
   # Need in binulils because /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
-  # TODO: for debugging, temporary:
-  - echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-  - printf "!! CC ${CC}\nC ${CXX}\n\n"
-  - printf "!! CC $(which $CC)\nC $(which $CXX)\n\n"
-  - env
-  - echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
 
 script:
   - mkdir -p build

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,11 +123,13 @@ script:
   - mkdir -p build
   - cd build
   - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
+  # Run unit-tests only
+  - ctest -R '.*-ut.*'
 
 after_script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
   # TODO: install Perl (DBI::ODBC) and Python (pyodbc) dependencies
-  - sudo apt install python-pip unixodbc-dev; pip install pyodbc
+  - sudo apt install python-pip unixodbc-dev; sudo pip install pyodbc
   - sudo apt install unixodbc
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
   # Test against the clickhouse-server:

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,14 +133,13 @@ after_script:
   - echo "Compose ODBC config"
   - |
     cat > ~/.odbc.ini <<-EOF
-[clickhouse_localhost]
-Driver=${ODBC_DRIVER_PATH}
-url=http://${CLICKHOUSE_SERVER_IP}
-
-[clickhouse_localhost_w]
-Driver=${ODBC_DRIVERW_PATH}
-url=http://${CLICKHOUSE_SERVER_IP}
-EOF
+    [clickhouse_localhost]
+    Driver=${ODBC_DRIVER_PATH}
+    url=http://${CLICKHOUSE_SERVER_IP}
+    [clickhouse_localhost_w]
+    Driver=${ODBC_DRIVERW_PATH}
+    url=http://${CLICKHOUSE_SERVER_IP}
+    EOF
   - cat ~/.odbc.ini
   - echo "run tests"
   - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
           addons:
             apt:
               sources: [ ubuntu-toolchain-r-test ]
-              packages: [ ninja-build, libstdc++-8-dev, libiodbc2-dev, libiodbc2 ]
+              packages: [ ninja-build, libstdc++-8-dev, iodbc, libiodbc2-dev, libiodbc2 ]
 
         # gcc8 iodbc
         - os: linux
@@ -63,7 +63,7 @@ matrix:
           addons:
             apt:
               sources: [ ubuntu-toolchain-r-test ]
-              packages: [ ninja-build, gcc-8, g++-8, libiodbc2-dev, libiodbc2 ]
+              packages: [ ninja-build, gcc-8, g++-8, iodbc, libiodbc2-dev, libiodbc2 ]
 
         # clang8 unixodbc
         #- os: linux
@@ -88,7 +88,7 @@ matrix:
           addons:
             apt:
               sources: [ ubuntu-toolchain-r-test ]
-              packages: [ ninja-build, gcc-7, g++-7 ]
+              packages: [ ninja-build, gcc-7, g++-7, unixodbc]
 
         - os: osx
           env: MATRIX_EVAL="export HOMEBREW_PACKAGES='libiodbc'" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,15 +132,15 @@ after_script:
   - ODBC_DRIVERW_PATH=$(realpath driver/libclickhouseodbc.so)
   - echo "Compose ODBC config"
   - |
-    cat <<-EOF
-    [clickhouse_localhost]
-    Driver=${ODBC_DRIVER_PATH}
-    url=http://${CLICKHOUSE_SERVER_IP}
+    cat > ~/.odbc.ini <<-EOF
+[clickhouse_localhost]
+Driver=${ODBC_DRIVER_PATH}
+url=http://${CLICKHOUSE_SERVER_IP}
 
-    [clickhouse_localhost_w]
-    Driver=${ODBC_DRIVERW_PATH}
-    url=http://${CLICKHOUSE_SERVER_IP}
-    EOF > ~/.odbc.ini
+[clickhouse_localhost_w]
+Driver=${ODBC_DRIVERW_PATH}
+url=http://${CLICKHOUSE_SERVER_IP}
+EOF
   - cat ~/.odbc.ini
   - echo "run tests"
   - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ services:
   - docker
 
 env:
-  - CLICKHOUSE_SERVER_IMAGE=yandex/clickhouse-server:19.11.8.46
+  global:
+    - CLICKHOUSE_SERVER_IMAGE=yandex/clickhouse-server:19.11.8.46
 
 addons:
   apt:
@@ -114,6 +115,7 @@ install:
   # Need in binulils bacause /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
   # TODO: Download image in background to save time
+  - echo "Clickhouse image: ${CLICKHOUSE_SERVER_IMAGE}"
   - sudo docker pull ${CLICKHOUSE_SERVER_IMAGE}
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ install:
 script:
   - mkdir -p build
   - cd build
-  - cmake ..  -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && ninja all
+  - cmake ..  -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
 
 after_script:
   # Test against the clickhouse-server:

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,8 @@ script:
   - sudo apt install perl libdbi-perl libdbd-odbc-perl python-pip unixodbc unixodbc-dev python-dev
   - sudo CC=`which $CC` CXX=`which $CXX` pip install pyodbc -V --disable-pip-version-check
   # To simplify things a bit, start ClickHouse server in docker
-  - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
+  - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}";
+  - docker pull ${CLICKHOUSE_SERVER_IMAGE}
   - CLICKHOUSE_SERVER_CONTAINER=$(docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
   - CLICKHOUSE_SERVER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})
   - docker ps -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,10 +119,11 @@ install:
   # Need in binulils because /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
 
-before_script:
-  # nanodbc for more tests
-  - cd ./contrib; git clone https://github.com/nanodbc/nanodbc; cd ..
-  - ls -lah . ./contrib
+# TODO: get nanodbc, right now it fails to build
+# before_script:
+#   # nanodbc for more tests
+#   - cd ./contrib; git clone https://github.com/nanodbc/nanodbc; cd ..
+#   - ls -lah . ./contrib
 
 script:
   - mkdir -p build

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,12 @@ matrix:
 
         # osx libiodbc unbundled
         - os: osx
-          env: MATRIX_EVAL="export CMAKE_FLAGS=-DUNBUNDLED=1"
+          env: MATRIX_EVAL="export CMAKE_FLAGS=-DUNBUNDLED=1 HOMEBREW_PACKAGES='libiodbc poco'" 
           git:
             submodules: false
-          addons:
-            homebrew:
-              packages: [ ninja, libiodbc, poco ]
+          # addons:
+          #   homebrew:
+          #     packages: [ ninja, libiodbc, poco ]
 
 
         # clang5 iodbc
@@ -91,14 +91,16 @@ matrix:
               packages: [ ninja-build, gcc-7, g++-7 ]
 
         - os: osx
-          addons:
-            homebrew:
-              packages: [ ninja, libiodbc ]
+          env: MATRIX_EVAL="export HOMEBREW_PACKAGES='libiodbc'" 
+          # addons:
+          #   homebrew:
+          #     packages: [ ninja, libiodbc ]
 
         - os: osx
-          addons:
-            homebrew:
-              packages: [ ninja, unixodbc ]
+          env: MATRIX_EVAL="export HOMEBREW_PACKAGES='unixodbc'" 
+          # addons:
+          #   homebrew:
+          #     packages: [ ninja, unixodbc ]
 
 
     exclude:
@@ -109,7 +111,7 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja ${HOMEBREW_PACKAGES}; fi
 
 install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,9 @@ matrix:
         - os: osx
           compiler: gcc
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi
 
 install:
   - eval "${MATRIX_EVAL}"
@@ -121,7 +124,7 @@ install:
 script:
   - mkdir -p build
   - cd build
-  - cmake ..  -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
+  - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
 
 after_script:
   # Test against the clickhouse-server:

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ script:
 after_script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
   # TODO: install Perl (DBI::ODBC) and Python (pyodbc) dependencies
-  - sudo apt install python-pip unixodbc-dev; sudo pip install pyodbc
+  - sudo apt install python-pip unixodbc-dev python-dev; sudo pip install pyodbc
   - sudo apt install unixodbc
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
   # Test against the clickhouse-server:

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ install:
 script:
   - mkdir -p build
   - cd build
-  - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS && ninja all && ninja test
+  - cmake ..  -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && ninja all
 
 after_script:
   # Test against the clickhouse-server:

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
   # TODO: Download image in background to save time
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"
-  - sudo docker pull ${CLICKHOUSE_SERVER_IMAGE}
+  - docker pull ${CLICKHOUSE_SERVER_IMAGE}
 
 script:
   - mkdir -p build
@@ -125,8 +125,8 @@ script:
 
 after_script:
   # Test against the clickhouse-server:
-  - CLICKHOUSE_SERVER_CONTAINER=$(sudo docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
-  - CLICKHOUSE_SERVER_IP=$(sudo docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})
+  - CLICKHOUSE_SERVER_CONTAINER=$(docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
+  - CLICKHOUSE_SERVER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})
   # TODO: think about paths on windows
   - ODBC_DRIVER_PATH=$(realpath driver/libclickhouseodbc.so)
   - ODBC_DRIVERW_PATH=$(realpath driver/libclickhouseodbc.so)

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,18 +110,18 @@ matrix:
           compiler: gcc
 
 before_install:
+  # brew update is to mitigate Travis error "Error: Your Homebrew is outdated. Please run `brew update`."
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja ${HOMEBREW_PACKAGES}; fi
+  # docker is not supported on OSX in Travis
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
 
 install:
   - eval "${MATRIX_EVAL}"
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu bionic main universe"; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get update -q > build.log 2>&1 || (cat build.log && exit 1); fi
-  # Need in binulils bacause /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
+  # Need in binulils because /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
-  # TODO: Download image in background to save time
-  - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"
-  - docker pull ${CLICKHOUSE_SERVER_IMAGE}
 
 script:
   - mkdir -p build
@@ -129,6 +129,7 @@ script:
   - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
 
 after_script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents. "; exit 0; fi
   # Test against the clickhouse-server:
   - CLICKHOUSE_SERVER_CONTAINER=$(docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
   - CLICKHOUSE_SERVER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
           addons:
             apt:
               sources: [ ubuntu-toolchain-r-test ]
-              packages: [ ninja-build, libstdc++-8-dev, iodbc, libiodbc2-dev, libiodbc2 ]
+              packages: [ ninja-build, libstdc++-8-dev, libiodbc2-dev, libiodbc2 ]
 
         # gcc8 iodbc
         - os: linux
@@ -63,7 +63,7 @@ matrix:
           addons:
             apt:
               sources: [ ubuntu-toolchain-r-test ]
-              packages: [ ninja-build, gcc-8, g++-8, iodbc, libiodbc2-dev, libiodbc2 ]
+              packages: [ ninja-build, gcc-8, g++-8, libiodbc2-dev, libiodbc2 ]
 
         # clang8 unixodbc
         #- os: linux
@@ -88,7 +88,7 @@ matrix:
           addons:
             apt:
               sources: [ ubuntu-toolchain-r-test ]
-              packages: [ ninja-build, gcc-7, g++-7, unixodbc]
+              packages: [ ninja-build, gcc-7, g++-7]
 
         - os: osx
           env: MATRIX_EVAL="export HOMEBREW_PACKAGES='libiodbc'" 
@@ -112,9 +112,7 @@ matrix:
 before_install:
   # brew update is to mitigate Travis error "Error: Your Homebrew is outdated. Please run `brew update`."
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja ${HOMEBREW_PACKAGES}; fi
-  # docker is not supported on OSX in Travis
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "installing ninja + ${HOMEBREW_PACKAGES}"; brew install ninja ${HOMEBREW_PACKAGES}; fi
 
 install:
   - eval "${MATRIX_EVAL}"
@@ -129,7 +127,11 @@ script:
   - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
 
 after_script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents. "; exit 0; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
+  # TODO: install Perl (DBI::ODBC) and Python (pyodbc) dependencies
+  - sudo apt install python-pip; pip install pyodbc
+  - sudo apt install unixodbc
+  - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
   # Test against the clickhouse-server:
   - CLICKHOUSE_SERVER_CONTAINER=$(docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
   - CLICKHOUSE_SERVER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,13 +109,11 @@ matrix:
         - os: osx
           compiler: gcc
 
-before_install:
-  # brew update is to mitigate Travis error "Error: Your Homebrew is outdated. Please run `brew update`."
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "installing ninja + ${HOMEBREW_PACKAGES}"; brew install ninja ${HOMEBREW_PACKAGES}; fi
-
 install:
   - eval "${MATRIX_EVAL}"
+    # brew update is to mitigate Travis error "Error: Your Homebrew is outdated. Please run `brew update`."
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "installing ninja + ${HOMEBREW_PACKAGES}"; brew install ninja ${HOMEBREW_PACKAGES}; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu bionic main universe"; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get update -q > build.log 2>&1 || (cat build.log && exit 1); fi
   # Need in binulils because /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
@@ -129,7 +127,7 @@ script:
 after_script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
   # TODO: install Perl (DBI::ODBC) and Python (pyodbc) dependencies
-  - sudo apt install python-pip; pip install pyodbc
+  - sudo apt install python-pip unixodbc-dev; pip install pyodbc
   - sudo apt install unixodbc
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
   # Test against the clickhouse-server:

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ install:
 
 before_script:
   # nanodbc for more tests
-  - cd /contrib; git clone https://github.com/nanodbc/nanodbc; cd ..
+  - cd ./contrib; git clone https://github.com/nanodbc/nanodbc; cd ..
   - ls -lah . ./contrib
 
 script:
@@ -134,6 +134,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
   # Setting up test prerequisites: docker, pyodbc, odbc module for perl, isql (or iusql or other)
   - sudo apt install perl libdbi-perl libdbd-odbc-perl python-pip unixodbc unixodbc-dev python-dev
+  # Using absolute path to compiler to fix setup.py issue of pyodbc: unable to execute 'clang': No such file or directory
   - sudo CC=`which $CC` CXX=`which $CXX` pip install pyodbc -V --disable-pip-version-check
   # To simplify things a bit, start ClickHouse server in docker
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ compiler:
 cache:
   ccache: true
 
+services:
+  - docker
+
+env:
+  - CLICKHOUSE_SERVER_IMAGE=yandex/clickhouse-server:19.11.8.46
+
 addons:
   apt:
      sources: [ ubuntu-toolchain-r-test ]
@@ -107,8 +113,32 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get update -q > build.log 2>&1 || (cat build.log && exit 1); fi
   # Need in binulils bacause /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
+  # TODO: Download image in background to save time
+  - sudo docker pull ${CLICKHOUSE_SERVER_IMAGE}
 
 script:
   - mkdir -p build
   - cd build
   - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS && ninja all && ninja test
+
+after_script:
+  # Test against the clickhouse-server:
+  - CLICKHOUSE_SERVER_CONTAINER=$(sudo docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
+  - CLICKHOUSE_SERVER_IP=$(sudo docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})
+  # TODO: think about paths on windows
+  - ODBC_DRIVER_PATH=$(realpath driver/libclickhouseodbc.so)
+  - ODBC_DRIVERW_PATH=$(realpath driver/libclickhouseodbc.so)
+  - echo "Compose ODBC config"
+  - |
+    cat <<-EOF
+    [clickhouse_localhost]
+    Driver=${ODBC_DRIVER_PATH}
+    url=http://${CLICKHOUSE_SERVER_IP}
+
+    [clickhouse_localhost_w]
+    Driver=${ODBC_DRIVERW_PATH}
+    url=http://${CLICKHOUSE_SERVER_IP}
+    EOF > ~/.odbc.ini
+  - cat ~/.odbc.ini
+  - echo "run tests"
+  - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ install:
   # Need in binulils bacause /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
   # TODO: Download image in background to save time
-  - echo "Clickhouse image: ${CLICKHOUSE_SERVER_IMAGE}"
+  - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"
   - sudo docker pull ${CLICKHOUSE_SERVER_IMAGE}
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,11 +123,11 @@ script:
   - mkdir -p build
   - cd build
   - cmake .. -G Ninja -DCMAKE_CXX_COMPILER=`which $CXX` -DCMAKE_C_COMPILER=`which $CC` $CMAKE_FLAGS -DTEST_DSN=clickhouse_localhost -DTEST_DSN_W=clickhouse_localhost_w && cmake --build . --target all
-  # Run unit-tests only
+  # unit-tests
   - ctest -R '.*-ut.*'
-
-after_script:
+  # more complicated tests
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
+  # Setting up test prerequisites: docker, pyodbc, odbc module for perl, isql (or iusql or other)
   # TODO: install Perl (DBI::ODBC) and Python (pyodbc) dependencies
   - sudo apt install python-pip unixodbc-dev python-dev; sudo pip install pyodbc
   - sudo apt install unixodbc
@@ -148,6 +148,5 @@ after_script:
     Driver=${ODBC_DRIVERW_PATH}
     url=http://${CLICKHOUSE_SERVER_IP}
     EOF
-  - cat ~/.odbc.ini
-  - echo "run tests"
+  - echo "Staring tests..."
   - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,10 +131,12 @@ script:
   # TODO: install Perl (DBI::ODBC) and Python (pyodbc) dependencies
   - sudo apt install python-pip unixodbc-dev python-dev; sudo pip install pyodbc
   - sudo apt install unixodbc
+  # To simplify things a bit, start ClickHouse server in docker
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
-  # Test against the clickhouse-server:
   - CLICKHOUSE_SERVER_CONTAINER=$(docker run  -d ${CLICKHOUSE_SERVER_IMAGE})
   - CLICKHOUSE_SERVER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${CLICKHOUSE_SERVER_CONTAINER})
+  - docker ps -a
+  - docker stats -a --no-stream
   # TODO: think about paths on windows
   - ODBC_DRIVER_PATH=$(realpath driver/libclickhouseodbc.so)
   - ODBC_DRIVERW_PATH=$(realpath driver/libclickhouseodbc.so)

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,13 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get update -q > build.log 2>&1 || (cat build.log && exit 1); fi
   # Need in binulils because /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libodbc.a(logOpen.o): unrecognized relocation (0x2a) in section `.text'
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ -n "$ODBC_LIB" ]; then sudo apt-get install -y $ODBC_LIB binutils | tee build.log 2>&1 || (cat build.log && exit 1); fi
+  # TODO: for debugging, temporary:
+  - echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  - printf "!! CC ${CC}\nC ${CXX}\n\n"
+  - printf "!! CC $(which $CC)\nC $(which $CXX)\n\n"
+  - env
+  - echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
 
 script:
   - mkdir -p build
@@ -129,7 +136,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo "Unable to test on OSX since docker is not supported on Travis OSX agents."; exit ${TRAVIS_TEST_RESULT}; fi
   # Setting up test prerequisites: docker, pyodbc, odbc module for perl, isql (or iusql or other)
   - sudo apt install perl libdbi-perl libdbd-odbc-perl python-pip unixodbc unixodbc-dev python-dev
-  - sudo pip install pyodbc
+  - sudo CC=`which $CC` CXX=`which $CXX` pip install pyodbc -V --disable-pip-version-check
   # To simplify things a bit, start ClickHouse server in docker
   - echo "Clickhouse image ${CLICKHOUSE_SERVER_IMAGE}"; docker pull ${CLICKHOUSE_SERVER_IMAGE}; fi
   - CLICKHOUSE_SERVER_CONTAINER=$(docker run  -d ${CLICKHOUSE_SERVER_IMAGE})

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,12 +16,12 @@
 #using trap to preserve error exit code
 #trap "printf '\n\n\nLast log:\n'; tail -n200 /tmp/clickhouse-odbc.log" EXIT
 
-DSN=${DSN=clickhouse_localhost}
+DSN="${DSN=clickhouse_localhost}"
 [ -z $RUNNER ] && RUNNER=`which isql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
 [ -z $RUNNER ] && RUNNER=`which iusql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
 [ -z $RUNNER ] && RUNNER=`which iodbctestw` && DSN="DSN=${DSN}"
 [ -z $RUNNER ] && RUNNER=`which iodbctest` && DSN="DSN=${DSN}"
-[ -z $RUNNER ] && echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages"; exit -1
+[ -z $RUNNER ] && echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages" && exit -1
 
 function q {
     echo "Asking [$*]"

--- a/test/test.sh
+++ b/test/test.sh
@@ -21,7 +21,6 @@ DSN="${DSN=clickhouse_localhost}"
 [ -z $RUNNER ] && RUNNER=`which iusql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
 [ -z $RUNNER ] && RUNNER=`which iodbctestw` && DSN="DSN=${DSN}"
 [ -z $RUNNER ] && RUNNER=`which iodbctest` && DSN="DSN=${DSN}"
-[ -z $RUNNER ] && echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages" && exit -1
 
 function q {
     echo "Asking [$*]"
@@ -31,6 +30,7 @@ function q {
 }
 
 echo "Using: $RUNNER $DSN $RUNNER_PARAMS0 $RUNNER_PARAMS"
+[ -z $RUNNER ] && echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages" && exit -1
 
 q "SELECT * FROM system.build_options;"
 q "CREATE DATABASE IF NOT EXISTS test;"

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,7 +14,7 @@
 # ./test.sh | grep -i error
 
 #using trap to preserve error exit code
-trap "printf '\n\n\nLast log:\n'; tail -n200 /tmp/clickhouse-odbc.log" EXIT
+#trap "printf '\n\n\nLast log:\n'; tail -n200 /tmp/clickhouse-odbc.log" EXIT
 
 DSN=${DSN=clickhouse_localhost}
 [ -z $RUNNER ] && RUNNER=`which isql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,8 +16,9 @@
 DSN=${DSN=clickhouse_localhost}
 [ -z $RUNNER ] && RUNNER=`which isql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
 [ -z $RUNNER ] && RUNNER=`which iusql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
-[ -z $RUNNER ] && RUNNER=`which iodbctestw`
-[ -z $RUNNER ] && RUNNER=`which iodbctest`
+[ -z $RUNNER ] && RUNNER=`which iodbctestw` && DSN="DSN=${DSN}"
+[ -z $RUNNER ] && RUNNER=`which iodbctest` && DSN="DSN=${DSN}"
+[ -z $RUNNER ] echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages"; exit -1
 
 function q {
     echo "Asking [$*]"

--- a/test/test.sh
+++ b/test/test.sh
@@ -13,6 +13,9 @@
 # Should not have any errors:
 # ./test.sh | grep -i error
 
+#using trap to preserve error exit code
+trap "printf '\n\n\nLast log:\n'; tail -n200 /tmp/clickhouse-odbc.log" EXIT
+
 DSN=${DSN=clickhouse_localhost}
 [ -z $RUNNER ] && RUNNER=`which isql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
 [ -z $RUNNER ] && RUNNER=`which iusql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
@@ -182,7 +185,3 @@ q "drop table test.lc;"
 
 
 # q "SELECT number, toString(number), toDate(number) FROM system.numbers LIMIT 10000;"
-
-echo "\n\n\nLast log:\n"
-# cat /tmp/clickhouse-odbc-stderr.$USER
-tail -n200 /tmp/clickhouse-odbc.log

--- a/test/test.sh
+++ b/test/test.sh
@@ -18,7 +18,7 @@ DSN=${DSN=clickhouse_localhost}
 [ -z $RUNNER ] && RUNNER=`which iusql` && [ -n $RUNNER ] && RUNNER_PARAMS0="-v -b"
 [ -z $RUNNER ] && RUNNER=`which iodbctestw` && DSN="DSN=${DSN}"
 [ -z $RUNNER ] && RUNNER=`which iodbctest` && DSN="DSN=${DSN}"
-[ -z $RUNNER ] echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages"; exit -1
+[ -z $RUNNER ] && echo "ERROR: unable to find neither of isql, iusql, iodbctestw, nor iodbctest. Please install missing packages"; exit -1
 
 function q {
     echo "Asking [$*]"


### PR DESCRIPTION
Testing driver not only with unit-tests, but also with test scripts from ./test directory
ClickHouse-server is started in docker;
Unfortunately, docker is not supported on MacOSX in Travis, so only running unit-tests
nanoodbc failed to build on Travis, hence not using it too.
