### PR TITLE
Fixed build on Debian and Ubuntu-based distros that override distribution ID

### DIFF
--- a/cmake/find_ltdl.cmake
+++ b/cmake/find_ltdl.cmake
@@ -1,28 +1,18 @@
 
 # /usr/bin/x86_64-linux-gnu-ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libltdl.a(libltdl_libltdl_la-lt__alloc.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
 if (NOT BUILD_SHARED AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    # using `/etc/debian_version` rather that `lsb_release -is` since some Ubuntu or Debian-based disros (hello KDE Neon)
+    # have different distribution ID, but `/etc/debian_version` MUST be present in all Debian-based disros.
     execute_process(
-        COMMAND lsb_release -is
-        OUTPUT_VARIABLE _distname
+        COMMAND cat /etc/debian_version
+        OUTPUT_VARIABLE _debian_version
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    if (_distname)
-        message (STATUS "lsb_release -is: ${_distname}")
-    else ()
-        execute_process(
-            COMMAND sh -c "head -n 1 /etc/issue | cut -f 1 -d ' '"
-            OUTPUT_VARIABLE _distname
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        if (_distname)
-            message (STATUS "Distro name from /etc/issue: ${_distname}")
-        endif ()
-    endif ()
 
-    if (_distname STREQUAL "Ubuntu" OR _distname STREQUAL "Debian")
+    if (_debian_version)
         list (REVERSE CMAKE_FIND_LIBRARY_SUFFIXES)
         set (_suffixes_reversed 1)
-        message (STATUS "Trying to find shared version of ltdl library because linking with libltdl.a is broken in ${_distname}")
+        message (STATUS "Trying to find shared version of ltdl library because linking with libltdl.a is broken in Debian-based distros")
     endif ()
 endif ()
 


### PR DESCRIPTION
Detecting that distro is Debian or Ubuntu-based not by distribution ID (with `lsb_release -is`) but from `/etc/debian_version`, which MUST be present for all Debian-based distros.