### PR TITLE
Treat unknown types as Strings in ODBCDriver2 format

### DIFF
--- a/driver/api/odbc.cpp
+++ b/driver/api/odbc.cpp
@@ -1011,10 +1011,19 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLColumns)(
                 TypeParser parser{type_name};
                 TypeAst ast;
 
-                if (!parser.parse(&ast))
-                    throw std::runtime_error("Unsupported type: " + type_name);
+                if (parser.parse(&ast)) {
+                    tmp_column_info.assignTypeInfo(ast);
 
-                tmp_column_info.assignTypeInfo(ast);
+                    if (convertUnparametrizedTypeNameToTypeId(tmp_column_info.type_without_parameters) == DataSourceTypeId::Unknown) {
+                        // Interpret all unknown types as String.
+                        tmp_column_info.type_without_parameters = "String";
+                    }
+                }
+                else {
+                    // Interpret all unparsable types as String.
+                    tmp_column_info.type_without_parameters = "String";
+                }
+
                 tmp_column_info.updateTypeInfo();
             }, row.fields.at(5).data);
 

--- a/driver/api/odbc.cpp
+++ b/driver/api/odbc.cpp
@@ -1013,9 +1013,14 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLColumns)(
 
                 if (parser.parse(&ast)) {
                     tmp_column_info.assignTypeInfo(ast);
+
+                    if (convertUnparametrizedTypeNameToTypeId(tmp_column_info.type_without_parameters) == DataSourceTypeId::Unknown) {
+                        // Interpret all unknown types as String.
+                        tmp_column_info.type_without_parameters = "String";
+                    }
                 }
                 else {
-                    // Interpret all unknown types as String.
+                    // Interpret all unparsable types as String.
                     tmp_column_info.type_without_parameters = "String";
                 }
 

--- a/driver/api/odbc.cpp
+++ b/driver/api/odbc.cpp
@@ -1011,19 +1011,10 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLColumns)(
                 TypeParser parser{type_name};
                 TypeAst ast;
 
-                if (parser.parse(&ast)) {
-                    tmp_column_info.assignTypeInfo(ast);
+                if (!parser.parse(&ast))
+                    throw std::runtime_error("Unsupported type: " + type_name);
 
-                    if (convertUnparametrizedTypeNameToTypeId(tmp_column_info.type_without_parameters) == DataSourceTypeId::Unknown) {
-                        // Interpret all unknown types as String.
-                        tmp_column_info.type_without_parameters = "String";
-                    }
-                }
-                else {
-                    // Interpret all unparsable types as String.
-                    tmp_column_info.type_without_parameters = "String";
-                }
-
+                tmp_column_info.assignTypeInfo(ast);
                 tmp_column_info.updateTypeInfo();
             }, row.fields.at(5).data);
 

--- a/driver/format/ODBCDriver2.cpp
+++ b/driver/format/ODBCDriver2.cpp
@@ -36,9 +36,14 @@ ODBCDriver2ResultSet::ODBCDriver2ResultSet(AmortizedIStreamReader & stream, std:
 
                 if (parser.parse(&ast)) {
                     columns_info[i].assignTypeInfo(ast);
+
+                    if (convertUnparametrizedTypeNameToTypeId(columns_info[i].type_without_parameters) == DataSourceTypeId::Unknown) {
+                        // Interpret all unknown types as String.
+                        columns_info[i].type_without_parameters = "String";
+                    }
                 }
                 else {
-                    // Interpret all unknown types as String.
+                    // Interpret all unparsable types as String.
                     columns_info[i].type_without_parameters = "String";
                 }
 

--- a/driver/format/RowBinaryWithNamesAndTypes.cpp
+++ b/driver/format/RowBinaryWithNamesAndTypes.cpp
@@ -24,7 +24,7 @@ RowBinaryWithNamesAndTypesResultSet::RowBinaryWithNamesAndTypesResultSet(Amortiz
             columns_info[i].assignTypeInfo(ast);
         }
         else {
-            // Interpret all unknown types as String.
+            // Interpret all unparsable types as String.
             columns_info[i].type_without_parameters = "String";
         }
 

--- a/driver/result_set.cpp
+++ b/driver/result_set.cpp
@@ -62,7 +62,7 @@ void ColumnInfo::assignTypeInfo(const TypeAst & ast) {
         assignTypeInfo(ast.elements.front());
     }
     else {
-        // Interpret all unrecognized ASTs as of String type.
+        // Interpret all types with unrecognized ASTs as String.
         type_without_parameters = "String";
     }
 }

--- a/driver/result_set.cpp
+++ b/driver/result_set.cpp
@@ -62,7 +62,7 @@ void ColumnInfo::assignTypeInfo(const TypeAst & ast) {
         assignTypeInfo(ast.elements.front());
     }
     else {
-        // Interpret all unsupported types as String.
+        // Interpret all unrecognized ASTs as of String type.
         type_without_parameters = "String";
     }
 }


### PR DESCRIPTION
...since they come as strings, they can be stored and served as strings.

Note, that this is not the case for `RowBinaryWithNamesAndTypes` format. When using it, unsupported types will cause hard failures.