### PR TITLE
Store and pass stateful converters in conversion contexts

### DIFF
--- a/driver/result_set.h
+++ b/driver/result_set.h
@@ -62,7 +62,8 @@ public:
         WireTypeDateTimeAsInt
     >;
 
-    SQLRETURN extract(BindingInfo & binding_info) const;
+    template <typename ConversionContext>
+    SQLRETURN extract(BindingInfo & binding_info, ConversionContext && context) const;
 
 public:
     DataType data = DataSourceType<DataSourceTypeId::Nothing>{};
@@ -70,7 +71,8 @@ public:
 
 class Row {
 public:
-    SQLRETURN extractField(std::size_t column_idx, BindingInfo & binding_info) const;
+    template <typename ConversionContext>
+    SQLRETURN extractField(std::size_t column_idx, BindingInfo & binding_info, ConversionContext && context) const;
 
 public:
     std::vector<Field> fields;
@@ -102,7 +104,7 @@ public:
     std::size_t getAffectedRowCount() const;
 
     // row_idx - row index within the row set.
-    SQLRETURN extractField(std::size_t row_idx, std::size_t column_idx, BindingInfo & binding_info) const;
+    SQLRETURN extractField(std::size_t row_idx, std::size_t column_idx, BindingInfo & binding_info);
 
 protected:
     void tryPrefetchRows(std::size_t size);
@@ -113,6 +115,7 @@ protected:
 protected:
     AmortizedIStreamReader & stream;
     std::unique_ptr<ResultMutator> result_mutator;
+    DefaultConversionContext conversion_context;
     std::vector<ColumnInfo> columns_info;
     std::deque<Row> row_set;
     std::size_t row_set_position = 0; // 1-based. 1 means the first row of the row set is the first row of the entire result set.
@@ -145,3 +148,23 @@ protected:
 };
 
 std::unique_ptr<ResultReader> make_result_reader(const std::string & format, std::istream & raw_stream, std::unique_ptr<ResultMutator> && mutator);
+
+template <typename ConversionContext>
+SQLRETURN Field::extract(BindingInfo & binding_info, ConversionContext && context) const {
+    return std::visit([&binding_info, &context] (auto & value) {
+        if constexpr (std::is_same_v<DataSourceType<DataSourceTypeId::Nothing>, std::decay_t<decltype(value)>>) {
+            return fillOutputNULL(binding_info.value, binding_info.value_max_size, binding_info.indicator);
+        }
+        else {
+            return writeDataFrom(value, binding_info, std::forward<ConversionContext>(context));
+        }
+    }, data);
+}
+
+template <typename ConversionContext>
+SQLRETURN Row::extractField(std::size_t column_idx, BindingInfo & binding_info, ConversionContext && context) const {
+    if (column_idx >= fields.size())
+        throw SqlException("Invalid descriptor index", "07009");
+
+    return fields[column_idx].extract(binding_info, std::forward<ConversionContext>(context));
+}

--- a/driver/utils/unicode_conv.h
+++ b/driver/utils/unicode_conv.h
@@ -18,8 +18,10 @@ public:
 public:
 //  std::locale source_locale;
 //  std::locale destination_locale;
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
     std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> UCS2_converter_char16;
     std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> UCS2_converter_char32;
+#endif
     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> UCS2_converter_wchar;
 };
 
@@ -216,6 +218,7 @@ inline decltype(auto) fromUTF8<unsigned char>(const std::string & src, UnicodeCo
     return std::basic_string<unsigned char>{converted.begin(), converted.end()};
 }
 
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
 template <>
 inline decltype(auto) fromUTF8<char16_t>(const std::string & src, UnicodeConversionContext & context) {
     return context.UCS2_converter_char16.from_bytes(src);
@@ -225,6 +228,7 @@ template <>
 inline decltype(auto) fromUTF8<char32_t>(const std::string & src, UnicodeConversionContext & context) {
     return context.UCS2_converter_char32.from_bytes(src);
 }
+#endif
 
 template <>
 inline decltype(auto) fromUTF8<wchar_t>(const std::string & src, UnicodeConversionContext & context) {

--- a/driver/utils/unicode_conv.h
+++ b/driver/utils/unicode_conv.h
@@ -235,12 +235,14 @@ inline decltype(auto) fromUTF8<wchar_t>(const std::string & src, UnicodeConversi
     return context.UCS2_converter_wchar.from_bytes(src);
 }
 
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
 template <>
 inline decltype(auto) fromUTF8<unsigned short>(const std::string & src, UnicodeConversionContext & context) {
     static_assert(sizeof(unsigned short) == sizeof(char16_t), "unsigned short doesn't match char16_t exactly");
     const auto converted = fromUTF8<char16_t>(src, context);
     return std::basic_string<unsigned short>{converted.begin(), converted.end()};
 }
+#endif
 
 template <typename CharType>
 inline decltype(auto) fromUTF8(const std::string & src) {


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-odbc/issues/220 (specific case described there).

Passing (reused persistent) context object with heavy converter instances to Unicode conversion functions.