### PR TITLE
Switch to ClickHouse version 20.3 as a baseline (changes NULL param string format)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:
@@ -60,7 +60,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:
@@ -89,7 +89,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:
@@ -118,7 +118,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:
@@ -151,7 +151,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:
@@ -179,7 +179,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:
@@ -208,7 +208,7 @@ jobs:
         - PACKAGING=yes
         - TESTING=yes
         - STANDALONE_TESTS_ONLY=no
-        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:19.11.8.46"
+        - CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse-server:20.3"
       services:
         - docker
       addons:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Pre-built binary packages of the release versions of the driver available for th
 
 - [Releases](https://github.com/ClickHouse/clickhouse-odbc/releases)
 
+The ODBC driver is mainly tested against ClickHouse server version `20.3`. Older versions of ClickHouse server as well as newer ones (with greater success) should work too. Possible complications with older version may include handling `Null` values and `Nullable` types, alternative wire protocol support, timezone handling during date/time conversions, etc.
+
 Note, that since ODBC drivers are not used directly by a user, but rather accessed through applications, which in their turn access the driver through ODBC driver manager, user have to install the driver for the **same architecture** (32- or 64-bit) as the application that is going to access the driver. Moreover, both the driver and the application must be compiled for (and actually use during run-time) the **same ODBC driver manager implementation** (we call them "ODBC providers" here). There are three supported ODBC providers:
 
 - ODBC driver manager associated with **MDAC** (Microsoft Data Access Components, sometimes referenced as WDAC, Windows Data Access Components) - the standard ODBC provider of Windows

--- a/driver/statement.cpp
+++ b/driver/statement.cpp
@@ -432,7 +432,7 @@ std::vector<ParamBindingInfo> Statement::getParamsBindingInfo(std::size_t param_
     const auto fully_bound_param_count = std::min(apd_record_count, ipd_record_count);
 
     // We allow (apd_record_count < ipd_record_count) here, since we will set
-    // all unbound parameters to 'Null' and their types to 'Nullable(Nothing)'.
+    // all unbound parameters to 'Null' and their types to 'Nullable(String)'.
 
     if (fully_bound_param_count > 0)
         param_bindings.reserve(fully_bound_param_count);

--- a/driver/statement.cpp
+++ b/driver/statement.cpp
@@ -307,7 +307,7 @@ std::string Statement::buildFinalQuery(const std::vector<ParamBindingInfo>& para
         std::string param_type;
 
         if (param_bindings.size() <= i) {
-            param_type = "Nullable(String)";
+            param_type = "Nullable(Nothing)";
         }
         else {
             const auto & binding_info = param_bindings[i];
@@ -432,7 +432,7 @@ std::vector<ParamBindingInfo> Statement::getParamsBindingInfo(std::size_t param_
     const auto fully_bound_param_count = std::min(apd_record_count, ipd_record_count);
 
     // We allow (apd_record_count < ipd_record_count) here, since we will set
-    // all unbound parameters to 'Null' and their types to 'Nullable(String)'.
+    // all unbound parameters to 'Null' and their types to 'Nullable(Nothing)'.
 
     if (fully_bound_param_count > 0)
         param_bindings.reserve(fully_bound_param_count);

--- a/driver/statement.cpp
+++ b/driver/statement.cpp
@@ -109,7 +109,7 @@ void Statement::requestNextPackOfResultSets(std::unique_ptr<ResultMutator> && mu
         std::string value;
 
         if (param_bindings.size() <= i) {
-            value = "Null";
+            value = "\\N";
         }
         else {
             const auto & binding_info = param_bindings[i];
@@ -118,7 +118,7 @@ void Statement::requestNextPackOfResultSets(std::unique_ptr<ResultMutator> && mu
                 throw std::runtime_error("Unable to extract data from bound param buffer: param IO type is not supported");
 
             if (binding_info.value == nullptr)
-                value = "Null";
+                value = "\\N";
             else
                 readReadyDataTo(binding_info, value);
         }
@@ -307,7 +307,7 @@ std::string Statement::buildFinalQuery(const std::vector<ParamBindingInfo>& para
         std::string param_type;
 
         if (param_bindings.size() <= i) {
-            param_type = "Nullable(Nothing)";
+            param_type = "Nullable(String)";
         }
         else {
             const auto & binding_info = param_bindings[i];

--- a/driver/test/statement_parameters_it.cpp
+++ b/driver/test/statement_parameters_it.cpp
@@ -122,7 +122,7 @@ TEST_F(StatementParametersTest, BindingNullStringValueForInteger) {
 #    define SQL_C_myTCHAR SQL_C_TCHAR
 #endif
 
-    auto param = fromUTF8<SQLmyTCHAR>("Null");
+    auto param = fromUTF8<SQLmyTCHAR>("\\N");
     SQLLEN param_ind = 0;
 
     auto * param_wptr = const_cast<SQLmyTCHAR *>(param.c_str());
@@ -201,7 +201,7 @@ TEST_F(StatementParametersTest, BindingNullStringValueForString) {
 #    define SQL_C_myTCHAR SQL_C_TCHAR
 #endif
 
-    auto param = fromUTF8<SQLmyTCHAR>("Null");
+    auto param = fromUTF8<SQLmyTCHAR>("\\N");
     SQLLEN param_ind = 0;
 
     auto * param_wptr = const_cast<SQLmyTCHAR *>(param.c_str());

--- a/test/deploy_and_run_clickhouse_macos.sh
+++ b/test/deploy_and_run_clickhouse_macos.sh
@@ -22,8 +22,8 @@ curl https://clickhouse-builds.s3.yandex.net/0/d147cd646a1e6cc41d42f92d57f016a5c
 curl https://clickhouse-builds.s3.yandex.net/0/d147cd646a1e6cc41d42f92d57f016a5c49d04de/clang-10-darwin_relwithdebuginfo_none_bundled_unsplitted_disable_False_binary/clickhouse-odbc-bridge -o usr/bin/clickhouse-odbc-bridge
 
 echo 3. Download configs
-curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.3/programs/server/config.xml -o etc/clickhouse-server/config.xml
-curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.3/programs/server/users.xml -o etc/clickhouse-server/users.xml
+curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.5/programs/server/config.xml -o etc/clickhouse-server/config.xml
+curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.5/programs/server/users.xml -o etc/clickhouse-server/users.xml
 
 echo 4. Setup executables
 pushd usr/bin/

--- a/test/deploy_and_run_clickhouse_macos.sh
+++ b/test/deploy_and_run_clickhouse_macos.sh
@@ -17,12 +17,13 @@ echo 1. Prepare folders
 mkdir -p usr/bin etc/clickhouse-server var/lib/clickhouse
 
 echo 2. Download binaries
-curl https://clickhouse-builds.s3.yandex.net/0/381947509a4f66236f943beaefb0b1f5c2fd979d/1570028580_binary/clickhouse -o usr/bin/clickhouse
-curl https://clickhouse-builds.s3.yandex.net/0/381947509a4f66236f943beaefb0b1f5c2fd979d/1570028580_binary/clickhouse-odbc-bridge -o usr/bin/clickhouse-odbc-bridge
+# TODO: switch to actual 20.3 binaries once available. Currently, this is master branch.
+curl https://clickhouse-builds.s3.yandex.net/0/d147cd646a1e6cc41d42f92d57f016a5c49d04de/clang-10-darwin_relwithdebuginfo_none_bundled_unsplitted_disable_False_binary/clickhouse -o usr/bin/clickhouse
+curl https://clickhouse-builds.s3.yandex.net/0/d147cd646a1e6cc41d42f92d57f016a5c49d04de/clang-10-darwin_relwithdebuginfo_none_bundled_unsplitted_disable_False_binary/clickhouse-odbc-bridge -o usr/bin/clickhouse-odbc-bridge
 
 echo 3. Download configs
-curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/v20.1.9.54-stable/dbms/programs/server/config.xml -o etc/clickhouse-server/config.xml
-curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/v20.1.9.54-stable/dbms/programs/server/users.xml -o etc/clickhouse-server/users.xml
+curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.3/programs/server/config.xml -o etc/clickhouse-server/config.xml
+curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.3/programs/server/users.xml -o etc/clickhouse-server/users.xml
 
 echo 4. Setup executables
 pushd usr/bin/


### PR DESCRIPTION
Closes #236
Closes #294
May help with #298 too

This changes are reflecting the following changes in ClickHouse server parameter parsing behavior: https://github.com/ClickHouse/ClickHouse/issues/7488 and https://github.com/ClickHouse/ClickHouse/pull/8517