### PR TITLE
Fix the behavior of SQLGetData for cases when the size of output buffer is 0

### DIFF
--- a/driver/test/misc_it.cpp
+++ b/driver/test/misc_it.cpp
@@ -3,6 +3,7 @@
 #include "driver/test/client_test_base.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 class MiscellaneousTest
     : public ClientTestBase
@@ -54,4 +55,49 @@ TEST_F(MiscellaneousTest, RowArraySizeAttribute) {
         rc = ODBC_CALL_ON_STMT_THROW(hstmt, SQLGetStmtAttr(hstmt, SQL_ATTR_ROW_ARRAY_SIZE, &size, sizeof(size), 0));
         ASSERT_EQ(size, 456);
     }
+}
+
+TEST_F(MiscellaneousTest, SQLGetData_ZeroOutputBufferSize) {
+    const std::string col_str = "1234567890";
+    const std::string query_orig = "SELECT CAST('" + col_str + "', 'String') AS col";
+
+    const auto query = fromUTF8<SQLTCHAR>(query_orig);
+    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
+
+    SQLTCHAR col[100] = {};
+    SQLLEN col_ind = 0;
+
+    SQLRETURN rc = SQLFetch(hstmt);
+
+    if (rc == SQL_ERROR)
+        throw std::runtime_error(extract_diagnostics(hstmt, SQL_HANDLE_STMT));
+
+    if (rc == SQL_SUCCESS_WITH_INFO)
+        std::cout << extract_diagnostics(hstmt, SQL_HANDLE_STMT) << std::endl;
+
+    if (!SQL_SUCCEEDED(rc))
+        throw std::runtime_error("SQLFetch return code: " + std::to_string(rc));
+
+    rc = SQLGetData(
+        hstmt,
+        1,
+        getCTypeFor<decltype(&col[0])>(),
+        &col,
+        0, // instead of sizeof(col)
+        &col_ind
+    );
+
+    if (!SQL_SUCCEEDED(rc))
+        throw std::runtime_error(extract_diagnostics(hstmt, SQL_HANDLE_STMT));
+
+    ASSERT_EQ(rc, SQL_SUCCESS_WITH_INFO);
+
+    const auto col_size_in_bytes = col_str.size() * sizeof(SQLTCHAR);
+    ASSERT_EQ(col_ind, col_size_in_bytes); // SQLGetData returns size in bytes in col_ind, even when the output buffer size is set to 0.
+    EXPECT_THAT(col, ::testing::Each(SQLTCHAR{}));
+
+    ASSERT_EQ(SQLFetch(hstmt), SQL_NO_DATA);
 }

--- a/driver/utils/type_info.h
+++ b/driver/utils/type_info.h
@@ -160,7 +160,7 @@ inline void fillOutputBufferInternal(
 
         auto bytes_to_copy = in_value_length;
 
-        if (out_value_max_length > 0 && out_value_max_length < bytes_to_copy)
+        if (out_value_max_length >= 0 && out_value_max_length < bytes_to_copy)
             bytes_to_copy = out_value_max_length;
 
         std::memcpy(out_value, in_value, bytes_to_copy);
@@ -207,7 +207,7 @@ inline SQLRETURN fillOutputString(
     ConversionContext && context
 ) {
     if (out_value) {
-        if (out_value_max_length <= 0)
+        if (out_value_max_length < 0)
             throw SqlException("Invalid string or buffer length", "HY090");
 
         if (out_length_in_bytes && (out_value_max_length % sizeof(CharType)) != 0)
@@ -242,8 +242,6 @@ inline SQLRETURN fillOutputString(
             reinterpret_cast<CharType *>(out_value)[converted_length_in_symbols] = CharType{};
         else if (out_value_max_length_in_symbols > 0)
             reinterpret_cast<CharType *>(out_value)[out_value_max_length_in_symbols - 1] = CharType{};
-        else
-            throw SqlException("Invalid string or buffer length", "HY090");
     }
 
     if ((converted_length_in_symbols + 1) > out_value_max_length_in_symbols) // +1 for null terminating character

--- a/test/deploy_and_run_clickhouse_macos.sh
+++ b/test/deploy_and_run_clickhouse_macos.sh
@@ -18,12 +18,13 @@ mkdir -p usr/bin etc/clickhouse-server var/lib/clickhouse
 
 echo 2. Download binaries
 # TODO: switch to actual 20.3 binaries once available. Currently, this is master branch.
-curl https://clickhouse-builds.s3.yandex.net/11870/009ddd5c8d46d1427c2775b67918e0165e50844f/clickhouse_build_check/clang-10-darwin_relwithdebuginfo_none_bundled_unsplitted_disable_False_binary/clickhouse -o usr/bin/clickhouse
-curl https://clickhouse-builds.s3.yandex.net/11870/009ddd5c8d46d1427c2775b67918e0165e50844f/clickhouse_build_check/clang-10-darwin_relwithdebuginfo_none_bundled_unsplitted_disable_False_binary/clickhouse-odbc-bridge -o usr/bin/clickhouse-odbc-bridge
+curl https://builds.clickhouse.tech/master/macos/clickhouse -o usr/bin/clickhouse
+curl https://builds.clickhouse.tech/master/macos/clickhouse-odbc-bridge -o usr/bin/clickhouse-odbc-bridge
 
 echo 3. Download configs
-curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.5/programs/server/config.xml -o etc/clickhouse-server/config.xml
-curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/20.5/programs/server/users.xml -o etc/clickhouse-server/users.xml
+# TODO: switch to the corresponding versions of configs when the binaries are fixed. Currently, this is master branch.
+curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/config.xml -o etc/clickhouse-server/config.xml
+curl https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/users.xml -o etc/clickhouse-server/users.xml
 
 echo 4. Setup executables
 pushd usr/bin/


### PR DESCRIPTION
Fixes #315.
May help with #307 (case 1).

https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/odbc/reference/syntax/sqlgetdata-function.md#L72