### PR TITLE
Disabled brew clang variant on CI/CD

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15]
+        os: [macos-11]
         odbc_provider: [UnixODBC, iODBC]
         # Once folly supports new clang (libcpp) add Clang to compilers:
         compiler: [AppleClang, GCC]

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -89,12 +89,14 @@ jobs:
 
     - name: Install dependencies - GCC
       if: ${{ matrix.compiler == 'GCC' }}
-      run: brew install gcc gdb
+      run: |
+        brew install gcc gdb
+        export COMPILER_PATH=$(brew prefix gcc)/bin
 
     - name: Configure
       run: >
-        CC=${{ fromJSON('{"AppleClang": "cc", "Clang": "/usr/local/opt/llvm/bin/clang", "GCC": "/usr/local/opt/gcc/bin/gcc-11"}')[matrix.compiler] }}
-        CXX=${{ fromJSON('{"AppleClang": "c++", "Clang": "/usr/local/opt/llvm/bin/clang++", "GCC": "/usr/local/opt/gcc/bin/g++-11"}')[matrix.compiler] }}
+        CC=${{ fromJSON('{"AppleClang": "cc", "Clang": "/usr/local/opt/llvm/bin/clang", "GCC": "$COMPILER_PATH/gcc-11"}')[matrix.compiler] }}
+        CXX=${{ fromJSON('{"AppleClang": "c++", "Clang": "/usr/local/opt/llvm/bin/clang++", "GCC": "$COMPILER_PATH/g++-11"}')[matrix.compiler] }}
         cmake -S ${{ github.workspace }}/source -B ${{ github.workspace }}/build
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DODBC_PROVIDER=${{ matrix.odbc_provider }}

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -31,7 +31,8 @@ jobs:
       matrix:
         os: [macos-10.15]
         odbc_provider: [UnixODBC, iODBC]
-        compiler: [AppleClang, Clang, GCC]
+        # Once folly supports new clang (libcpp) add Clang to compilers:
+        compiler: [AppleClang, GCC]
         build_type: [Debug, RelWithDebInfo, Release]
         architecture: [x86_64]
         runtime_link: [dynamic-runtime]
@@ -80,9 +81,11 @@ jobs:
       if: ${{ matrix.odbc_provider == 'iODBC' }}
       run: brew install libiodbc
 
-    - name: Install dependencies - Clang
-      if: ${{ matrix.compiler == 'Clang' }}
-      run: brew install llvm
+    # Right now folly fails to compile and link against brew's clang & libcpp versions 11-14
+    # Since Clang is removed from list of compilers in matrix, this will not be executed.
+    # - name: Install dependencies - Clang
+    #   if: ${{ matrix.compiler == 'Clang' }}
+    #   run: brew install llvm
 
     - name: Install dependencies - GCC
       if: ${{ matrix.compiler == 'GCC' }}


### PR DESCRIPTION
It is not properly supported right now and fails to compile in multiple ways.
Checked against clang 11-14