### PR TITLE
Removed windows-2016 from matrix

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2016]
+        os: [windows-2019]
         odbc_provider: [MDAC]
         compiler: [MSVC]
         build_type: [Debug, RelWithDebInfo, Release]


### PR DESCRIPTION
Windows-2016 server hosted runners are no longer available:
https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/