### PR TITLE
Fix issues with the locate function call

### DIFF
--- a/driver/test/escape_sequences_ut.cpp
+++ b/driver/test/escape_sequences_ut.cpp
@@ -298,8 +298,21 @@ TEST(EscapeSequencesCase, DateTime) {
 }
 
 TEST(EscapeSequencesCase, LOCATE) {
-    ASSERT_EQ(replaceEscapeSequences("{fn LOCATE('Xsell',`dm_ExperimentsData`.`ProductLevel`,1)}"),
-        "position(`dm_ExperimentsData`.`ProductLevel`,'Xsell')");
+    ASSERT_EQ(replaceEscapeSequences(
+        "SELECT {fn LOCATE('needle', `haystack`, 42)}"),
+        "SELECT locate('needle',`haystack`,accurateCast(42,'UInt64'))");
+    ASSERT_EQ(replaceEscapeSequences(
+        "SELECT {fn LOCATE(?, `haystack`, 42)}"),
+        "SELECT locate(?,`haystack`,accurateCast(42,'UInt64'))");
+    ASSERT_EQ(replaceEscapeSequences(
+        "SELECT {fn LOCATE('needle', `haystack`, ?)}"),
+        "SELECT locate('needle',`haystack`,accurateCast(?,'UInt64'))");
+    ASSERT_EQ(replaceEscapeSequences(
+        "SELECT {fn LOCATE('needle', `haystack`)}"),
+        "SELECT locate('needle',`haystack`,accurateCast(1,'UInt64'))");
+    ASSERT_EQ(replaceEscapeSequences(
+        "SELECT {fn LOCATE(?, `haystack`)}"),
+        "SELECT locate(?,`haystack`,accurateCast(1,'UInt64'))");
 }
 
 TEST(EscapeSequencesCase, LCASE) {


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/clickhouse-odbc/issues/466:
- Fixes an issue where the call to the locate function always ignores the `start_pos` parameter.
- Fixes an issue where the call to the locate function results in an error when `start_pos` is not specified.

Additionally:
- Ensures that the order of arguments remains unchanged during escape sequence replacement. To achieve this, ClickHouse's `position` function has been replaced with ClickHouse's `locate` function, which has the same argument order as the ODBC `locate` function.
- Also fixes https://github.com/ClickHouse/clickhouse-odbc/issues/462