### PR TITLE
Free pointer `pAdapterInfo` before the function `nodeIdImpl` returns

### DIFF
--- a/contrib/poco/Foundation/src/Environment_WIN32.cpp
+++ b/contrib/poco/Foundation/src/Environment_WIN32.cpp
@@ -190,7 +190,8 @@ void EnvironmentImpl::nodeIdImpl(NodeId& id)
 	}
 	else if (rc != ERROR_SUCCESS)
 	{
-		return;
+		delete[] reinterpret_cast<char*>(pAdapterInfo);
+        return;
 	}
 	if (GetAdaptersInfo(pAdapterInfo, &len) == NO_ERROR) 
 	{


### PR DESCRIPTION
In function `nodeIdImpl`, the pointer `pAdapterInfo` at line 8 cannot reach any free site before the function returns at line 19. Thus there is a memory leak bug. Here is the original code:
```c++
	pAdapterInfo = reinterpret_cast<IP_ADAPTER_INFO*>(new char[len]);         // memory allocated here
	// Make an initial call to GetAdaptersInfo to get
	// the necessary size into len
	DWORD rc = GetAdaptersInfo(pAdapterInfo, &len);
	if (rc == ERROR_BUFFER_OVERFLOW) 
	{
		delete [] reinterpret_cast<char*>(pAdapterInfo);
		pAdapterInfo = reinterpret_cast<IP_ADAPTER_INFO*>(new char[len]);
	}
	else if (rc != ERROR_SUCCESS)
	{
		return;          // memory leak here
	}

``` 
We add a free operation before the return statement. 