### PR TITLE
Reset the read buffer of Poco's SecureSocketImpl before the handshake

### DIFF
--- a/contrib/poco/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/contrib/poco/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -777,6 +777,8 @@ void SecureSocketImpl::performInitialClientHandshake()
 	// get initial security token
 	_outSecBuffer.reset(true);
 	_outSecBuffer.setSecBufferToken(0, 0, 0);
+	_recvBuffer.setCapacity(IO_BUFFER_SIZE);
+	_recvBufferOffset = 0;
 
 	TimeStamp ts;
 	DWORD contextAttributes(0);


### PR DESCRIPTION
When the SecureSocketImpl instance is reused after being closed — either due to a timeout or by SQLFreeStmt(stmt, SQL_CLOSE) — the new handshake might run with a read buffer that has shrunk to the size of the last payload, while still assuming it retains its initial size. This occurs in SecureSocketImpl::performClientHandshakeLoopReceive():

```
int n = receiveRawBytes(
    _recvBuffer.begin() + _recvBufferOffset,
    IO_BUFFER_SIZE - _recvBufferOffset);
```

Here, the code assumes that the buffer is at least IO_BUFFER_SIZE. However, after the connection is reused, the buffer may be smaller. To fix this, we restore the buffer size to the expected IO_BUFFER_SIZE before performing the handshake. This fix is taken from the latest version of the Poco library.

In the future, we should update the entire Poco library to the latest version.