### PR TITLE
Fix CI

### DIFF
--- a/test/docker-compose/config.xml
+++ b/test/docker-compose/config.xml
@@ -32,4 +32,11 @@
     <flush_interval_milliseconds>1000</flush_interval_milliseconds>
   </query_log>
 
+  <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
+  <user_directories>
+    <users_xml>
+      <path>users.xml</path>
+    </users_xml>
+  </user_directories>
+
 </clickhouse>


### PR DESCRIPTION
The configuration options `format_schema_path` and `user_directories.users_xml.path` are now required in ClickHouse 24.3.18.7 and later.