### PR TITLE
Fix integration tests for Windows

### DIFF
--- a/driver/test/client_utils.h
+++ b/driver/test/client_utils.h
@@ -17,7 +17,7 @@ namespace {
         SQLRETURN rc = SQL_SUCCESS;
 
         do {
-            rc = SQLGetDiagRec(type, handle, ++i, state, &native, text, sizeof(text), &len);
+            rc = SQLGetDiagRec(type, handle, ++i, state, &native, text, std::size(text), &len);
             if (SQL_SUCCEEDED(rc)) {
                 if (!result.empty())
                     result += '\n';

--- a/driver/test/datetime_it.cpp
+++ b/driver/test/datetime_it.cpp
@@ -71,6 +71,12 @@ TEST_P(DateTime, GetData) {
 
     const auto orig_local_tz = get_env_var("TZ");
     set_env_var("TZ", params.local_tz);
+
+#ifdef _win_
+    _putenv_s("TZ", params.local_tz.c_str());
+    _tzset();
+#endif
+
     try {
 
     const std::string query_orig = "SELECT " + params.expr + " AS col FORMAT " + params.format;

--- a/driver/test/misc_it.cpp
+++ b/driver/test/misc_it.cpp
@@ -21,7 +21,7 @@ TEST_F(MiscellaneousTest, RowArraySizeAttribute) {
     }
     
     {
-        size = 0;
+        size = 2;
         rc = ODBC_CALL_ON_STMT_THROW(hstmt, SQLSetStmtAttr(hstmt, SQL_ATTR_ROW_ARRAY_SIZE, (SQLPOINTER)size, 0));
         ASSERT_EQ(rc, SQL_SUCCESS);
     }
@@ -29,7 +29,7 @@ TEST_F(MiscellaneousTest, RowArraySizeAttribute) {
     {
         size = 123;
         rc = ODBC_CALL_ON_STMT_THROW(hstmt, SQLGetStmtAttr(hstmt, SQL_ATTR_ROW_ARRAY_SIZE, &size, sizeof(size), 0));
-        ASSERT_EQ(size, 0);
+        ASSERT_EQ(size, 2);
     }
 
     {

--- a/driver/test/statement_parameter_bindings_it.cpp
+++ b/driver/test/statement_parameter_bindings_it.cpp
@@ -100,27 +100,11 @@ TEST_F(StatementParameterBindingsTest, NoBuffer) {
     ASSERT_EQ(SQLFetch(hstmt), SQL_NO_DATA);
 }
 
-TEST_F(StatementParameterBindingsTest, NullStringValueForInteger) {
+TEST_F(StatementParameterBindingsTest, NullValueForInteger) {
     const auto query = fromUTF8<SQLTCHAR>("SELECT isNull(?)");
     auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
 
-#if defined(_IODBCUNIX_H)
-    // iODBC workaround: disable potential use of SQLWCHAR in this test case,
-    // since iODBC, for reasons unknown, changes the 4th argument of SQLBindParameter()
-    // from SQL_C_WCHAR to SQL_C_CHAR, if this client is Unicode and the driver pointed by DSN is ANSI,
-    // but does not convert the actual buffer (naturally). This makes the driver unable to interpret the buffer correctly.
-    // TODO: eventually review and fix or report a defect on iODBC, if it doesn't have any reasonable explanation.
-#    define SQLmyTCHAR SQLCHAR
-#    define SQL_C_myTCHAR SQL_C_CHAR
-#else
-#    define SQLmyTCHAR SQLTCHAR
-#    define SQL_C_myTCHAR SQL_C_TCHAR
-#endif
-
-    auto param = fromUTF8<SQLmyTCHAR>("\\N");
-    SQLLEN param_ind = 0;
-
-    auto * param_wptr = const_cast<SQLmyTCHAR *>(param.c_str());
+    SQLLEN param_ind = SQL_NULL_DATA;
 
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
@@ -128,36 +112,18 @@ TEST_F(StatementParameterBindingsTest, NullStringValueForInteger) {
             hstmt,
             1,
             SQL_PARAM_INPUT,
-            SQL_C_myTCHAR,
+            SQL_C_TCHAR,
             SQL_INTEGER,
-            param.size(),
             0,
-            param_wptr,
-            param.size() * sizeof(SQLTCHAR),
+            0,
+            nullptr,
+            0,
             &param_ind
         )
     );
 
-#undef SQLmyTCHAR
-#undef SQL_C_myTCHAR
-
-    // TODO: Workaround for workaround for https://github.com/ClickHouse/ClickHouse/issues/7488 . Remove when sorted-out.
-    // Strictly speaking, this is not allowed, and parameters must always be nullable.
-    SQLHDESC hdesc = 0;
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLGetStmtAttr(hstmt, SQL_ATTR_IMP_PARAM_DESC, &hdesc, 0, NULL));
-    ODBC_CALL_ON_DESC_THROW(hdesc, SQLSetDescField(hdesc, 1, SQL_DESC_NULLABLE, reinterpret_cast<SQLPOINTER>(SQL_NULLABLE), 0));
-
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
-    SQLRETURN rc = SQLFetch(hstmt);
-
-    if (rc == SQL_ERROR)
-        throw std::runtime_error(extract_diagnostics(hstmt, SQL_HANDLE_STMT));
-
-    if (rc == SQL_SUCCESS_WITH_INFO)
-        std::cout << extract_diagnostics(hstmt, SQL_HANDLE_STMT) << std::endl;
-
-    if (!SQL_SUCCEEDED(rc))
-        throw std::runtime_error("SQLFetch return code: " + std::to_string(rc));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLFetch(hstmt));
 
     SQLINTEGER col = 0;
     SQLLEN col_ind = 0;
@@ -179,27 +145,11 @@ TEST_F(StatementParameterBindingsTest, NullStringValueForInteger) {
     ASSERT_EQ(SQLFetch(hstmt), SQL_NO_DATA);
 }
 
-TEST_F(StatementParameterBindingsTest, NullStringValueForString) {
+TEST_F(StatementParameterBindingsTest, NullValueForString) {
     const auto query = fromUTF8<SQLTCHAR>("SELECT isNull(?)");
     auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
 
-#if defined(_IODBCUNIX_H)
-    // iODBC workaround: disable potential use of SQLWCHAR in this test case,
-    // since iODBC, for reasons unknown, changes the 4th argument of SQLBindParameter()
-    // from SQL_C_WCHAR to SQL_C_CHAR, if this client is Unicode and the driver pointed by DSN is ANSI,
-    // but does not convert the actual buffer (naturally). This makes the driver unable to interpret the buffer correctly.
-    // TODO: eventually review and fix or report a defect on iODBC, if it doesn't have any reasonable explanation.
-#    define SQLmyTCHAR SQLCHAR
-#    define SQL_C_myTCHAR SQL_C_CHAR
-#else
-#    define SQLmyTCHAR SQLTCHAR
-#    define SQL_C_myTCHAR SQL_C_TCHAR
-#endif
-
-    auto param = fromUTF8<SQLmyTCHAR>("\\N");
-    SQLLEN param_ind = 0;
-
-    auto * param_wptr = const_cast<SQLmyTCHAR *>(param.c_str());
+    SQLLEN param_ind = SQL_NULL_DATA;
 
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
@@ -207,36 +157,18 @@ TEST_F(StatementParameterBindingsTest, NullStringValueForString) {
             hstmt,
             1,
             SQL_PARAM_INPUT,
-            SQL_C_myTCHAR,
-            SQL_CHAR,
-            param.size(),
+            SQL_C_WCHAR,
+            SQL_VARCHAR,
             0,
-            param_wptr,
-            param.size() * sizeof(SQLTCHAR),
+            0,
+            nullptr,
+            0,
             &param_ind
         )
     );
 
-#undef SQLmyTCHAR
-#undef SQL_C_myTCHAR
-
-    // TODO: Workaround for workaround for https://github.com/ClickHouse/ClickHouse/issues/7488 . Remove when sorted-out.
-    // Strictly speaking, this is not allowed, and parameters must always be nullable.
-    SQLHDESC hdesc = 0;
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLGetStmtAttr(hstmt, SQL_ATTR_IMP_PARAM_DESC, &hdesc, 0, NULL));
-    ODBC_CALL_ON_DESC_THROW(hdesc, SQLSetDescField(hdesc, 1, SQL_DESC_NULLABLE, reinterpret_cast<SQLPOINTER>(SQL_NULLABLE), 0));
-
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
-    SQLRETURN rc = SQLFetch(hstmt);
-
-    if (rc == SQL_ERROR)
-        throw std::runtime_error(extract_diagnostics(hstmt, SQL_HANDLE_STMT));
-
-    if (rc == SQL_SUCCESS_WITH_INFO)
-        std::cout << extract_diagnostics(hstmt, SQL_HANDLE_STMT) << std::endl;
-
-    if (!SQL_SUCCEEDED(rc))
-        throw std::runtime_error("SQLFetch return code: " + std::to_string(rc));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLFetch(hstmt));
 
     SQLINTEGER col = 0;
     SQLLEN col_ind = 0;


### PR DESCRIPTION
Additionally removed `NullStringValueForInteger` and `NullStringValueForString` because their purpose was unclear and they contradicted ODBC specifications. These tests worked mysteriously with iODBC and unixODBC but failed on Windows, as passing SQL_DESC_NULLABLE to SQLSetDescField is not allowed. According to ODBC specifications, the indicator variable should be used when binding NULL to parameters or SQLBindColumn. These tests did not reflect any realistic real-world scenario unless artificially reproduced.

Note: The PR does not enable the integration tests for Windows on CI.