### PR TITLE
Suggest use of Nullable(Decimal) for overflow-prone operations

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   release:
     types:
       - created

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   release:
     types:
       - created

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   release:
     types:
       - created


### PR DESCRIPTION
Power BI casts numeric types (e.g., `Int32`, `UInt64`, etc.) to `Decimal` to avoid overflow. However, this cast fails when applied to nullable types. To address this, the change proposes that Power BI use `Nullable(Decimal)` instead of `Decimal`. This is achieved by placing `Nullable(Decimal)` before `Decimal` in the `SQLGetTypeInfo` result.

In practical terms, instead of using: `SUM(CAST(value as Decimal))` Power BI will now  use `SELECT SUM(CAST(value as Nullable(Decimal)))`. This prevents errors when value is `NULL`.

**Important note**: This change breaks any existing projections that rely on casting to `Decimal` before aggregation. Affected projections must be updated to use `CAST(value AS Nullable(Decimal))` instead of `CAST(value AS Decimal)`.

Additionally, all types returned by SQLGetTypeInfo are now ordered by compatibility with SQL types, ensuring that the client applications chose right underlying types.