### PR TITLE
Enable GitHub Actions for all PRs

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   release:
     types:
       - created

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   release:
     types:
       - created

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   release:
     types:
       - created


### PR DESCRIPTION
Previously, we only ran GitHub Actions for PRs targeting the `master` branch. However, we sometimes have parallel branches, such as the `beta` branch.