### PR TITLE
Enable unit and integration tests in the Windows pipeline

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -16,9 +16,6 @@ concurrency:
   group: windows-${{ github.head_ref }}
   cancel-in-progress: true
 
-env:
-  CLICKHOUSE_SERVER_IMAGE: "yandex/clickhouse-server:20.3"
-
 defaults:
   run:
     shell: powershell
@@ -30,13 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [windows-2025]
         odbc_provider: [MDAC]
-        compiler: [MSVC]
         build_type: [Debug, Release]
         architecture: [x86, x64]
-        runtime_link: [dynamic-runtime]
-        third_parties: [bundled-third-parties]
+        wsl_distribution: [Ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}
 
@@ -52,7 +47,7 @@ jobs:
         new-item ${{ github.workspace }}/package -itemtype directory
 
     - name: Clone the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: source
         submodules: true
@@ -62,23 +57,15 @@ jobs:
       with:
         arch: ${{ matrix.architecture }}
 
-    # - name: Install dependencies - Docker
-    #   if: ${{ matrix.os != 'windows-2016' }}
-    #   run: |
-    #     choco install wsl2 --params "/Version:2 /Retry:true" --yes
-    #     choco install docker-desktop --yes
-    #     & "C:\Program Files\Docker\Docker\Docker Desktop.exe"
-
-    - name: Configure
+    - name: Configure with CMake
       run: >
         cmake -S ${{ github.workspace }}/source -B ${{ github.workspace }}/build
         -A ${{ fromJSON('{"x86": "Win32", "x64": "x64"}')[matrix.architecture] }}
-        -DCMAKE_SYSTEM_VERSION="${{ fromJSON('{"windows-2016": "10.0.17763.0", "windows-2019": "10.0.19041.685"}')[matrix.os] }}"
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DODBC_PROVIDER=${{ matrix.odbc_provider }}
-        -DCH_ODBC_RUNTIME_LINK_STATIC=${{ fromJSON('{"static-runtime": "ON", "dynamic-runtime": "OFF"}')[matrix.runtime_link] }}
-        -DCH_ODBC_PREFER_BUNDLED_THIRD_PARTIES=${{ fromJSON('{"bundled-third-parties": "ON", "system-third-parties": "OFF"}')[matrix.third_parties] }}
-        -DTEST_DSN_LIST="ClickHouse DSN (ANSI);ClickHouse DSN (Unicode);ClickHouse DSN (ANSI, RBWNAT)"
+        -DCH_ODBC_RUNTIME_LINK_STATIC=OFF
+        -DCH_ODBC_PREFER_BUNDLED_THIRD_PARTIES=ON
+        -DTEST_DSN_LIST="ClickHouse DSN ANSI;ClickHouse DSN Unicode"
 
     - name: Build
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }}
@@ -91,8 +78,7 @@ jobs:
         echo REF: ${{ github.ref }}
         dir ${{ github.workspace }}/build
 
-    - name: Upload the artifacts
-      # if:  ${{ matrix.os == 'windows-2019' && matrix.build_type == 'Release' }}
+    - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
           name: clickhouse-odbc-windows-${{ matrix.architecture }}-${{ matrix.build_type }}
@@ -102,90 +88,117 @@ jobs:
       working-directory: ${{ github.workspace }}/build
       run: ctest --output-on-failure --build-config ${{ matrix.build_type }} -R '.*-ut.*'
 
-    # - name: Test - Start ClickHouse server in background
-    #   if: ${{ matrix.os != 'windows-2016' }}
-    #   run: |
-    #     docker pull ${env:CLICKHOUSE_SERVER_IMAGE}
-    #     docker run -d --name clickhouse ${env:CLICKHOUSE_SERVER_IMAGE}
-    #     docker ps -a
-    #     docker stats -a --no-stream
+    - name: Register ODBC driver in Windows Registry
+      run: |
+        $driverDir = "${{ github.workspace }}\build\driver\${{ matrix.build_type }}"
+        $driverSection = "${{ fromJSON('{"x86": "WOW6432Node\\ODBC", "x64": "ODBC"}')[matrix.architecture] }}"
+        $escapedDriverDir = $driverDir.Replace('\', '\\')
 
-    # - name: Test - Run integration tests
-    #   if: ${{ matrix.os != 'windows-2016' }}
-    #   working-directory: ${{ github.workspace }}/build
-    #   run: |
-    #     export CLICKHOUSE_SERVER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' clickhouse)
+        $regContent = @"
+        Windows Registry Editor Version 5.00
 
-    #     export ODBCSYSINI=${{ github.workspace }}/run
-    #     export ODBCINSTINI=.odbcinst.ini
-    #     export ODBCINI=$ODBCSYSINI/.odbc.ini
-    #     if [[ "${{ matrix.odbc_provider }}" == "iODBC" ]]; then
-    #         # Full path to a custom odbcinst.ini in ODBCINSTINI for iODBC.
-    #         export ODBCINSTINI=$ODBCSYSINI/$ODBCINSTINI
-    #     fi
+        [HKEY_LOCAL_MACHINE\SOFTWARE\$driverSection\ODBCINST.INI\ODBC Drivers]
+        "ClickHouse ODBC Driver (ANSI)"="Installed"
+        "ClickHouse ODBC Driver (Unicode)"="Installed"
 
-    #     cat > $ODBCSYSINI/.odbcinst.ini <<-EOF
-    #     [ODBC]
-    #     Trace     = 1
-    #     TraceFile = ${{ github.workspace }}/run/odbc-driver-manager-trace.log
-    #     Debug     = 1
-    #     DebugFile = ${{ github.workspace }}/run/odbc-driver-manager-debug.log
+        [HKEY_LOCAL_MACHINE\SOFTWARE\$driverSection\ODBCINST.INI\ClickHouse ODBC Driver (ANSI)]
+        "Description"="ODBC Driver (ANSI) for ClickHouse"
+        "Driver"="$escapedDriverDir\\clickhouseodbc.dll"
+        "Setup"="$escapedDriverDir\\clickhouseodbc.dll"
+        "DriverODBCVer"="03.80"
+        "ConnectFunctions"="YYN"
+        "APILevel"="1"
+        "SQLLevel"="1"
+        "FileUsage"="0"
 
-    #     [ODBC Drivers]
-    #     ClickHouse ODBC Driver (ANSI)    = Installed
-    #     ClickHouse ODBC Driver (Unicode) = Installed
+        [HKEY_LOCAL_MACHINE\SOFTWARE\$driverSection\ODBCINST.INI\ClickHouse ODBC Driver (Unicode)]
+        "Description"="ODBC Driver (Unicode) for ClickHouse"
+        "Driver"="$escapedDriverDir\\clickhouseodbcw.dll"
+        "Setup"="$escapedDriverDir\\clickhouseodbcw.dll"
+        "DriverODBCVer"="03.80"
+        "ConnectFunctions"="YYN"
+        "APILevel"="1"
+        "SQLLevel"="1"
+        "FileUsage"="0"
+        "@
 
-    #     [ClickHouse ODBC Driver (ANSI)]
-    #     Driver     = ${{ github.workspace }}/build/driver/libclickhouseodbc.so
-    #     Setup      = ${{ github.workspace }}/build/driver/libclickhouseodbc.so
-    #     UsageCount = 1
+        Write-Host "Writing the registry file"
+        $regContent | Out-File -FilePath ${{ github.workspace }}/run/driver.reg -Encoding ASCII
+        Get-Content ${{ github.workspace }}/run/driver.reg
 
-    #     [ClickHouse ODBC Driver (Unicode)]
-    #     Driver     = ${{ github.workspace }}/build/driver/libclickhouseodbcw.so
-    #     Setup      = ${{ github.workspace }}/build/driver/libclickhouseodbcw.so
-    #     UsageCount = 1
-    #     EOF
+        Write-Host "Exporting the file to the registry"
+        reg import ${{ github.workspace }}/run/driver.reg
 
-    #     cat > $ODBCSYSINI/.odbc.ini <<-EOF
-    #     [ODBC]
-    #     Trace     = 1
-    #     TraceFile = ${{ github.workspace }}/run/odbc-driver-manager-trace.log
-    #     Debug     = 1
-    #     DebugFile = ${{ github.workspace }}/run/odbc-driver-manager-debug.log
+        Write-Host "Registry keys after export"
+        reg query "HKEY_LOCAL_MACHINE\SOFTWARE\$driverSection\ODBCINST.INI\" /s
 
-    #     [ODBC Data Sources]
-    #     ClickHouse DSN (ANSI)         = ClickHouse ODBC Driver (ANSI)
-    #     ClickHouse DSN (Unicode)      = ClickHouse ODBC Driver (Unicode)
-    #     ClickHouse DSN (ANSI, RBWNAT) = ClickHouse ODBC Driver (ANSI)
+    - name: Configure ClickHouse ODBC DSNs
+      run: |
+        $platform = "${{ fromJSON('{"x86": "32-bit", "x64": "64-bit"}')[matrix.architecture] }}"
 
-    #     [ClickHouse DSN (ANSI)]
-    #     Driver        = ClickHouse ODBC Driver (ANSI)
-    #     Description   = Test DSN for ClickHouse ODBC Driver (ANSI)
-    #     Url           = http://${CLICKHOUSE_SERVER_IP}
-    #     DriverLog     = yes
-    #     DriverLogFile = ${{ github.workspace }}/run/clickhouse-odbc-driver.log
+        Add-OdbcDsn `
+          -Name "ClickHouse DSN ANSI" `
+          -DriverName "ClickHouse ODBC Driver (ANSI)" `
+          -DsnType "System" `
+          -Platform "$platform" `
+          -SetPropertyValue @("Url=http://127.0.0.1:8123/", "User=default")
 
-    #     [ClickHouse DSN (Unicode)]
-    #     Driver        = ClickHouse ODBC Driver (Unicode)
-    #     Description   = Test DSN for ClickHouse ODBC Driver (Unicode)
-    #     Url           = http://${CLICKHOUSE_SERVER_IP}
-    #     DriverLog     = yes
-    #     DriverLogFile = ${{ github.workspace }}/run/clickhouse-odbc-driver-w.log
+        Add-OdbcDsn `
+          -Name "ClickHouse DSN Unicode" `
+          -DriverName "ClickHouse ODBC Driver (Unicode)" `
+          -DsnType "System" `
+          -Platform "$platform" `
+          -SetPropertyValue @("Url=http://127.0.0.1:8123/", "User=default")
 
-    #     [ClickHouse DSN (ANSI, RBWNAT)]
-    #     Driver        = ClickHouse ODBC Driver (ANSI)
-    #     Description   = Test DSN for ClickHouse ODBC Driver (ANSI) that uses RowBinaryWithNamesAndTypes as data source communication default format
-    #     Url           = http://${CLICKHOUSE_SERVER_IP}/query?default_format=RowBinaryWithNamesAndTypes
-    #     DriverLog     = yes
-    #     DriverLogFile = ${{ github.workspace }}/run/clickhouse-odbc-driver.log
-    #     EOF
+        Write-Host "List of enabled DSNs:"
+        Get-OdbcDsn -DsnType "System"
 
-    #     if [[ "${{ matrix.odbc_provider }}" == "iODBC" ]]; then
-    #         export GTEST_FILTER="-PerformanceTest.*"
-    #     fi
+    - name: Enable WSL and Install Dependencies
+      uses: Vampire/setup-wsl@v5
+      with:
+          distribution: ${{ matrix.wsl_distribution }}
+          additional-packages:
+            podman
+            podman-compose
 
-    #     # Run all tests except those that were run in "Test - unit tests" step.
-    #     ctest --output-on-failure --build-config ${{ matrix.build_type }} -E '.*-ut.*'
+    - name: Start ClickHouse Server
+      shell: wsl-bash {0}
+      run: |
+        echo "Starting ClickHouse container"
+        cd $(wslpath -u "${{ github.workspace }}/source/test/")
+        podman-compose up -d
+
+        echo "Waiting for ClickHouse to start..."
+        timeout 60s bash -c \
+            'until curl -s -o /dev/null -w "%{http_code}" http://localhost:8123 | grep -q "200"; do sleep 2; done'
+
+        echo "Checking ClickHouse version"
+        curl -s http://localhost:8123/?query=SELECT%20VERSION%28%29
+
+    - name: Ping ClickHouse Server from Windows
+      run: |
+          Invoke-WebRequest -Uri http://localhost:8123/?query=SELECT%20VERSION%28%29
+
+    - name: Test - Run integration tests
+      working-directory: ${{ github.workspace }}/build
+      run: |
+        ctest --output-on-failure --build-config ${{ matrix.build_type }} -E '.*-ut.*'
+
+    - name: Test - Run Python e2e tests for the ANSI driver
+      if: ${{ matrix.architecture == 'x64' }}
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN ANSI"
+      run: |
+        Write-Host "Check python version and architecture"
+        python --version
+        python -c "import platform; print(platform.architecture()[0])"
+
+        Write-Host "Prepare Python dependencies"
+        python -m pip install -r requirements.txt
+
+        Write-Host "Run tests"
+        python -m pytest --log-level=DEBUG -v
 
     - name: Upload artifacts as release assets
       if: ${{ github.event_name == 'release' && matrix.build_type == 'Release' }}
@@ -196,3 +209,4 @@ jobs:
         overwrite: true
         tag: ${{ github.ref }}
         file_glob: true
+

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     clickhouse:
-        image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
+        image: 'docker.io/clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
         container_name: 'clickhouse-odbc-clickhouse-server'
         environment:
             CLICKHOUSE_SKIP_USER_SETUP: 1
@@ -12,8 +12,8 @@ services:
                 soft: 262144
                 hard: 262144
         volumes:
-            - './docker-compose/config.xml:/etc/clickhouse-server/config.xml'
-            - './docker-compose/users.xml:/etc/clickhouse-server/users.xml'
+            - './docker-compose/config.xml:/etc/clickhouse-server/config.xml:z'
+            - './docker-compose/users.xml:/etc/clickhouse-server/users.xml:z'
         networks:
             - clickhouse-odbc
 


### PR DESCRIPTION
This change enables integration tests, including the Python-based tests, in the Windows CI workflow. The preferred approach was to reuse as much as possible from the existing and functional Linux workflow. However, ClickHouse does not run natively on Windows, nor does Docker, which is used to run ClickHouse in the Linux workflow. To address this, additional steps were added to the workflow: install WSL2 with Ubuntu 24.04, and install Podman as a drop-in replacement for Docker within the WSL2 environment.

Details:

- Updated the GitHub Actions runner image from `windows-2019` to `windows-2025`, which supports WSL2.
- Added steps to enable WSL with `Ubuntu-24.04`, install Podman on it, and run `podman-compose` to start a ClickHouse server, similar to the Linux workflow.
- Modified `docker-compose.yml` to enable shared mode for mounted volumes (i.e., `:z` in volume bindings), which is required by Podman.
- Podman also requires the image name to include the registry (e.g., `docker.io/...`). Both changes to `docker-compose.yml` remain compatible with Docker Compose.
- Adding the driver to the system is slightly different than on Linux; the simplest approach in this case was to add it directly to the registry.
- DSNs are added using the `Add-OdbcDsn` command. Note that it is not recommended to use parentheses in DSN names, so they were renamed: `ClickHouse DSN ANSI` instead of `ClickHouse DSN (ANSI)` and `ClickHouse DSN Unicode` instead of `ClickHouse DSN (Unicode)`.

**Important note:** These additions generally support both the `32-bit` and `64-bit` drivers. However, testing the `32-bit` driver with the Python-based integration tests would require installing a `32-bit` version of Python, which introduces extra steps for a platform we do not fully support at the moment. As a result, Python tests are completely disabled for the `32-bit` driver. C++-based integration tests remain enabled for both driver variants.