### PR TITLE
Enable Python E2E tests for the Unicode Driver

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -191,11 +191,22 @@ jobs:
       run: |
         pip install -r requirements.txt
 
-      # An empty `ODBCSYSINI` is required in this case to run properly with custom `ODBCINI`/`ODBCINSTINI` paths
-    - name: Test - Run Python e2e tests
+    - name: Test - Run Python e2e tests for the ANSI driver
       working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN (ANSI)"
+        ODBCSYSINI: ""  # Must be set for `ODBCINSTINI` and `ODBCINI` to work
+        ODBCINSTINI: ${{ github.workspace }}/run/.odbcinst.ini
+        ODBCINI: ${{ github.workspace }}/run/.odbc.ini
       run: |
-        export ODBCSYSINI=
-        export ODBCINSTINI="${{ github.workspace }}/run/.odbcinst.ini"
-        export ODBCINI="${{ github.workspace }}/run/.odbc.ini"
+        pytest --log-level=DEBUG -v
+
+    - name: Test - Run Python e2e tests for the Unicode driver
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN (Unicode)"
+        ODBCSYSINI: ""  # Must be set for `ODBCINSTINI` and `ODBCINI` to work
+        ODBCINSTINI: ${{ github.workspace }}/run/.odbcinst.ini
+        ODBCINI: ${{ github.workspace }}/run/.odbc.ini
+      run: |
         pytest --log-level=DEBUG -v

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -184,11 +184,9 @@ jobs:
       run: |
         ctest --output-on-failure --build-config ${{ matrix.build_type }} -E '.*-ut.*'
 
-    - name: Test - Run Python e2e tests for the ANSI driver
+    - name: Prepare Pythons dependencies
       if: ${{ matrix.architecture == 'x64' }}
       working-directory: source/test
-      env:
-        DSN: "ClickHouse DSN ANSI"
       run: |
         Write-Host "Check python version and architecture"
         python --version
@@ -197,7 +195,20 @@ jobs:
         Write-Host "Prepare Python dependencies"
         python -m pip install -r requirements.txt
 
-        Write-Host "Run tests"
+    - name: Test - Run Python e2e tests for the ANSI driver
+      if: ${{ matrix.architecture == 'x64' }}
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN ANSI"
+      run: |
+        python -m pytest --log-level=DEBUG -v
+
+    - name: Test - Run Python e2e tests for the Unicode driver
+      if: ${{ matrix.architecture == 'x64' }}
+      working-directory: source/test
+      env:
+        DSN: "ClickHouse DSN Unicode"
+      run: |
         python -m pytest --log-level=DEBUG -v
 
     - name: Upload artifacts as release assets


### PR DESCRIPTION
It is generally not recommended to pass values directly in SQL statements when using pyodbc; instead, values should be passed as parameters. However, in our tests, we specifically want to embed values in the SQL statement and then verify the result using a parameterized query.

To avoid unexpected character encoding/decoding issues, all values containing special characters are now base64-encoded in the SQL statements and decoded by ClickHouse.

Additionally, all tables created during testing are now properly deleted.