### PR TITLE
Remove use of non-standard std::char_traits

### DIFF
--- a/driver/api/impl/impl.cpp
+++ b/driver/api/impl/impl.cpp
@@ -172,7 +172,7 @@ SQLRETURN SetConnectAttr(
             }
 
             case SQL_ATTR_CURRENT_CATALOG:
-                connection.database = toUTF8((SQLTCHAR *)value, value_length / sizeof(SQLTCHAR));
+                connection.database = toUTF8(static_cast<PTChar*>(value), value_length / sizeof(PTChar));
                 return SQL_SUCCESS;
 
             case SQL_ATTR_ANSI_APP:
@@ -193,7 +193,7 @@ SQLRETURN SetConnectAttr(
             }
 
             case CH_SQL_ATTR_DRIVERLOGFILE:
-                connection.getDriver().setAttr(CH_SQL_ATTR_DRIVERLOGFILE, toUTF8((SQLTCHAR *)value, value_length / sizeof(SQLTCHAR)));
+                connection.getDriver().setAttr(CH_SQL_ATTR_DRIVERLOGFILE, toUTF8(static_cast<PTChar*>(value), value_length / sizeof(PTChar)));
                 return SQL_SUCCESS;
 
 #if defined(SQL_APPLICATION_NAME)
@@ -251,7 +251,7 @@ SQLRETURN GetConnectAttr(
             CASE_NUM(SQL_ATTR_AUTOCOMMIT, SQLINTEGER, SQL_AUTOCOMMIT_ON);
 
             case SQL_ATTR_CURRENT_CATALOG:
-                return fillOutputString<SQLTCHAR>(
+                return fillOutputString<PTChar>(
                     connection.database,
                     out_value, out_value_max_length, out_value_length, true
                 );
@@ -266,7 +266,7 @@ SQLRETURN GetConnectAttr(
                 );
 
             case CH_SQL_ATTR_DRIVERLOGFILE:
-                return fillOutputString<SQLTCHAR>(
+                return fillOutputString<PTChar>(
                     connection.getDriver().getAttrAs<std::string>(CH_SQL_ATTR_DRIVERLOGFILE),
                     out_value, out_value_max_length, out_value_length, true
                 );
@@ -542,14 +542,14 @@ SQLRETURN GetDiagRec(
         if (out_sqlstate) {
             std::size_t size = 6;
             std::size_t written = 0;
-            fillOutputString<SQLTCHAR>(record.template getAttrAs<std::string>(SQL_DIAG_SQLSTATE), out_sqlstate, size, &written, false);
+            fillOutputString<PTChar>(record.template getAttrAs<std::string>(SQL_DIAG_SQLSTATE), out_sqlstate, size, &written, false);
         }
 
         if (out_native_error_code != nullptr) {
             *out_native_error_code = record.template getAttrAs<SQLINTEGER>(SQL_DIAG_NATIVE);
         }
 
-        return fillOutputString<SQLTCHAR>(record.template getAttrAs<std::string>(SQL_DIAG_MESSAGE_TEXT), out_message, out_message_max_size, out_message_size, false);
+        return fillOutputString<PTChar>(record.template getAttrAs<std::string>(SQL_DIAG_MESSAGE_TEXT), out_message, out_message_max_size, out_message_size, false);
     };
 
     return CALL_WITH_TYPED_HANDLE_SKIP_DIAG(handle_type, handle, func);
@@ -604,7 +604,7 @@ SQLRETURN GetDiagField(
 
 #define CASE_ATTR_STR(NAME) \
     case NAME: \
-        return fillOutputString<SQLTCHAR>(record.template getAttrAs<std::string>(NAME), out_message, out_message_max_size, out_message_size, true);
+        return fillOutputString<PTChar>(record.template getAttrAs<std::string>(NAME), out_message, out_message_max_size, out_message_size, true);
 
             CASE_ATTR_NUM(SQL_DIAG_CURSOR_ROW_COUNT, SQLLEN);
             CASE_ATTR_STR(SQL_DIAG_DYNAMIC_FUNCTION);
@@ -963,7 +963,7 @@ SQLRETURN GetDescField(
             case NAME: return fillOutputPOD<TYPE>(record.getAttrAs<TYPE>(NAME, DEFAULT), ValuePtr, StringLengthPtr);
 
 #define CASE_FIELD_STR(NAME) \
-            case NAME: return fillOutputString<SQLTCHAR>(record.getAttrAs<std::string>(NAME), ValuePtr, BufferLength, StringLengthPtr, true);
+            case NAME: return fillOutputString<PTChar>(record.getAttrAs<std::string>(NAME), ValuePtr, BufferLength, StringLengthPtr, true);
 
             CASE_FIELD_NUM     ( SQL_DESC_AUTO_UNIQUE_VALUE,           SQLINTEGER                              );
             CASE_FIELD_STR     ( SQL_DESC_BASE_COLUMN_NAME                                                     );
@@ -1055,7 +1055,7 @@ SQLRETURN GetDescRec(
         if (NullablePtr && record.hasAttrInteger(SQL_DESC_NULLABLE))
             *NullablePtr = record.getAttrAs<SQLSMALLINT>(SQL_DESC_NULLABLE);
 
-        return fillOutputString<SQLTCHAR>(record.getAttrAs<std::string>(SQL_DESC_NAME), Name, BufferLength, StringLengthPtr, false);
+        return fillOutputString<PTChar>(record.getAttrAs<std::string>(SQL_DESC_NAME), Name, BufferLength, StringLengthPtr, false);
     };
 
     return CALL_WITH_TYPED_HANDLE(SQL_HANDLE_DESC, DescriptorHandle, func);

--- a/driver/api/odbc.cpp
+++ b/driver/api/odbc.cpp
@@ -132,7 +132,7 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLGetInfo)(
 
 #define CASE_STRING(NAME, VALUE) \
             case NAME:           \
-                return fillOutputString<SQLTCHAR>(VALUE, out_value, out_value_max_length, out_value_length, true);
+                return fillOutputString<PTChar>(VALUE, out_value, out_value_max_length, out_value_length, true);
 
             CASE_STRING(SQL_DRIVER_VER, VERSION_STRING)
             CASE_STRING(SQL_DRIVER_ODBC_VER, "03.80")
@@ -489,7 +489,7 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLDriverConnect)(
         }
 
         connection.connect(connection_string);
-        return fillOutputString<SQLTCHAR>(connection_string, OutConnectionString, out_buffer_length, StringLength2Ptr, false);
+        return fillOutputString<PTChar>(connection_string, OutConnectionString, out_buffer_length, StringLength2Ptr, false);
     });
 }
 
@@ -599,7 +599,7 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLColAttribute)(
                 return SQL_SUCCESS;
 
 #define CASE_FIELD_STR(NAME, VALUE) \
-            case NAME: return fillOutputString<SQLTCHAR>(VALUE, out_string_value, out_string_value_max_size, out_string_value_size, true);
+            case NAME: return fillOutputString<PTChar>(VALUE, out_string_value, out_string_value_max_size, out_string_value_size, true);
 
             // TODO: Use IRD (the descriptor) when column data representation is migrated there.
 
@@ -700,7 +700,7 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLDescribeCol)(HSTMT statement_hand
         if (out_is_nullable)
             *out_is_nullable = column_info.is_nullable ? SQL_NULLABLE : SQL_NO_NULLS;
 
-        return fillOutputString<SQLTCHAR>(column_info.name, out_column_name, out_column_name_max_size, out_column_name_size, false);
+        return fillOutputString<PTChar>(column_info.name, out_column_name, out_column_name_max_size, out_column_name_size, false);
     };
 
     return CALL_WITH_TYPED_HANDLE(SQL_HANDLE_STMT, statement_handle, func);
@@ -1156,7 +1156,7 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLNativeSql)(HDBC connection_handle
 
     return CALL_WITH_TYPED_HANDLE(SQL_HANDLE_DBC, connection_handle, [&](Connection & connection) {
         std::string query_str = toUTF8(query, query_length);
-        return fillOutputString<SQLTCHAR>(query_str, out_query, out_query_max_length, out_query_length, false);
+        return fillOutputString<PTChar>(query_str, out_query, out_query_max_length, out_query_length, false);
     });
 }
 

--- a/driver/config/config.h
+++ b/driver/config/config.h
@@ -35,7 +35,5 @@ struct ConnInfo {
     std::string auto_session_id;
 };
 
-void readDSNinfo(ConnInfo * ci, bool overwrite);
-void writeDSNinfo(const ConnInfo * ci);
 key_value_map_t readDSNInfo(const std::string & dsn);
 key_value_map_t readConnectionString(const std::string & connection_string);

--- a/driver/platform/platform.h
+++ b/driver/platform/platform.h
@@ -72,24 +72,6 @@
 #        define strcpy strcpy_s
 #        define stricmp _stricmp
 #    endif
-#else
-
-// Fix missing declarations in iodbc
-#    if defined(_IODBCUNIX_H)
-#        if defined(UNICODE)
-#            define LPTSTR LPWSTR
-#        else
-#            define LPTSTR LPSTR
-#        endif
-#    endif
-#    if !defined(LPCTSTR)
-#        if defined(UNICODE)
-#            define LPCTSTR LPCWSTR
-#        else
-#            define LPCTSTR LPCSTR
-#        endif
-#    endif
-
 #endif
 
 #define SIZEOF_CHAR sizeof(SQLTCHAR)
@@ -134,3 +116,4 @@
 
 #define CH_SQL_ATTR_DRIVERLOG            (SQL_ATTR_TRACE + CH_SQL_OFFSET)
 #define CH_SQL_ATTR_DRIVERLOGFILE        (SQL_ATTR_TRACEFILE + CH_SQL_OFFSET)
+

--- a/driver/test/buffer_filling_ut.cpp
+++ b/driver/test/buffer_filling_ut.cpp
@@ -1,5 +1,6 @@
 #include "driver/utils/utils.h"
 #include "driver/utils/type_info.h"
+#include "driver/test/client_utils.h"
 
 #include <gtest/gtest.h>
 
@@ -108,8 +109,8 @@ INSTANTIATE_TEST_SUITE_P(                     \
     )                                         \
 );
 
-using SQLNarrowChar = SQLCHAR;
-using SQLWideChar = SQLWCHAR;
+using SQLNarrowChar = char;
+using SQLWideChar = char16_t;
 
 DECLARE_TEST_GROUP(SQLNarrowChar);
 DECLARE_TEST_GROUP(SQLWideChar);

--- a/driver/test/client_test_base.h
+++ b/driver/test/client_test_base.h
@@ -42,10 +42,10 @@ protected:
         ODBC_CALL_ON_ENV_THROW(henv, SQLAllocHandle(SQL_HANDLE_DBC, henv, &hdbc));
 
         if (!skip_connect_) {
-            const auto dsn = fromUTF8<SQLTCHAR>(TestEnvironment::getInstance().getDSN());
-            auto * dsn_wptr = const_cast<SQLTCHAR *>(dsn.c_str());
+            auto dsn = fromUTF8<PTChar>(TestEnvironment::getInstance().getDSN());
+            auto * dsn_wptr =dsn.data();
 
-            ODBC_CALL_ON_DBC_THROW(hdbc, SQLConnect(hdbc, dsn_wptr, SQL_NTS, NULL, 0, NULL, 0));
+            ODBC_CALL_ON_DBC_THROW(hdbc, SQLConnect(hdbc, ptcharCast(dsn_wptr), SQL_NTS, NULL, 0, NULL, 0));
             ODBC_CALL_ON_DBC_THROW(hdbc, SQLAllocHandle(SQL_HANDLE_STMT, hdbc, &hstmt));
         }
     }

--- a/driver/test/client_utils.h
+++ b/driver/test/client_utils.h
@@ -11,13 +11,13 @@ namespace {
         std::string result;
         SQLSMALLINT i = 0;
         SQLINTEGER native = 0;
-        SQLTCHAR state[6] = {};     // Exactly 6 char long buffer to store 5 char long SQLSTATE string plus the terminating null.
-        SQLTCHAR text[10240] = {};  // A reasonably long buffer to store diagnostics messages.
+        PTChar state[6] = {};     // Exactly 6 char long buffer to store 5 char long SQLSTATE string plus the terminating null.
+        PTChar text[10240] = {};  // A reasonably long buffer to store diagnostics messages.
         SQLSMALLINT len = 0;
         SQLRETURN rc = SQL_SUCCESS;
 
         do {
-            rc = SQLGetDiagRec(type, handle, ++i, state, &native, text, std::size(text), &len);
+            rc = SQLGetDiagRec(type, handle, ++i, ptcharCast(state), &native, ptcharCast(text), std::size(text), &len);
             if (SQL_SUCCEEDED(rc)) {
                 if (!result.empty())
                     result += '\n';

--- a/driver/test/column_bindings_it.cpp
+++ b/driver/test/column_bindings_it.cpp
@@ -43,12 +43,11 @@ SELECT
 FROM numbers(
     )SQL" + std::to_string(total_rows_expected) + ")";
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR *>(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
     // Prepare, execute, and set attribues on te statement.
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLSetStmtAttr(hstmt, SQL_ATTR_ROW_BIND_TYPE, (SQLPOINTER)SQL_BIND_BY_COLUMN, 0));
@@ -288,12 +287,11 @@ SELECT
 FROM numbers(
     )SQL" + std::to_string(total_rows_expected) + ")";
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR *>(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
     // Prepare, execute, and set attribues on te statement.
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     struct Bindings {

--- a/driver/test/datetime_it.cpp
+++ b/driver/test/datetime_it.cpp
@@ -73,7 +73,7 @@ TEST_P(DateTime, GetData) {
     setEnvVar("TZ", params.local_tz);
 
 #ifdef _win_
-    _putenv_s("TZ", params.local_tz.c_str());
+    _putenv_s("TZ", params.local_tz.data());
     _tzset();
 #endif
 
@@ -81,10 +81,9 @@ TEST_P(DateTime, GetData) {
 
     const std::string query_orig = "SELECT " + params.expr + " AS col FORMAT " + params.format;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecDirect(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecDirect(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLFetch(hstmt));
 
     {
@@ -94,7 +93,7 @@ TEST_P(DateTime, GetData) {
     }
 
     {
-        SQLTCHAR col[64] = {};
+        PTChar col[64] = {};
         SQLLEN col_ind = 0;
 
         ODBC_CALL_ON_STMT_THROW(hstmt, SQLGetData(

--- a/driver/test/performance_it.cpp
+++ b/driver/test/performance_it.cpp
@@ -58,12 +58,11 @@ private:
 // API call that doesn't reach the driver, i.e., this is effectively (somewhat incomplete) Driver Manager overhead, just for the reference.
 TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(UnimplementedAPICallOverhead)) {
     constexpr std::size_t call_count = 1'000'000;
-    const auto tstr = fromUTF8<SQLTCHAR>("");
-    auto * tstr_wptr = const_cast<SQLTCHAR * >(tstr.c_str());
+    auto tstr = fromUTF8<PTChar>("");
 
     // Verify that SQLStatistics() is not implemented. Change to something else when implemented.
     {
-        const auto rc = SQLStatistics(hstmt, tstr_wptr, 0, tstr_wptr, 0, tstr_wptr, 0, SQL_INDEX_ALL, SQL_ENSURE);
+        const auto rc = SQLStatistics(hstmt, ptcharCast(tstr.data()), 0, ptcharCast(tstr.data()), 0, ptcharCast(tstr.data()), 0, SQL_INDEX_ALL, SQL_ENSURE);
         if (rc != SQL_ERROR) {
             throw std::runtime_error(
                 "SQLStatistics return code: " + std::to_string(rc) +
@@ -82,7 +81,7 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(UnimplementedAPICallOve
     START_MEASURING_TIME();
 
     for (std::size_t i = 0; i < call_count; ++i) {
-        SQLStatistics(hstmt, tstr_wptr, 0, tstr_wptr, 0, tstr_wptr, 0, SQL_INDEX_ALL, SQL_ENSURE);
+        SQLStatistics(hstmt, ptcharCast(tstr.data()), 0, ptcharCast(tstr.data()), 0, ptcharCast(tstr.data()), 0, SQL_INDEX_ALL, SQL_ENSURE);
     }
 
     STOP_MEASURING_TIME_AND_REPORT(call_count);
@@ -94,10 +93,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(NoOpAPICallOverhead)) {
 
     // Verify that several consequent SQLNumResultCols() calls  on an executed statement, without destination buffer, return SQL_SUCCESS.
     {
-        const auto query = fromUTF8<SQLTCHAR>("SELECT 1");
-        auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+        auto query = fromUTF8<PTChar>("SELECT 1");
 
-        ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecDirect(hstmt, query_wptr, SQL_NTS));
+        ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecDirect(hstmt, ptcharCast(query.data()), SQL_NTS));
         ODBC_CALL_ON_STMT_THROW(hstmt, SQLNumResultCols(hstmt, nullptr));
         ODBC_CALL_ON_STMT_THROW(hstmt, SQLNumResultCols(hstmt, nullptr));
         ODBC_CALL_ON_STMT_THROW(hstmt, SQLNumResultCols(hstmt, nullptr));
@@ -118,10 +116,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchNoExtractMultiType
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     std::size_t total_rows = 0;
@@ -158,10 +155,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchGetDataMultiType))
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLTCHAR col1[32] = {};
@@ -253,10 +249,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchBindColMultiType))
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLTCHAR col1[32] = {};
@@ -348,10 +343,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchBindColSingleType_
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLCHAR col[32] = {};
@@ -401,10 +395,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchBindColSingleType_
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLWCHAR col[32] = {};
@@ -454,10 +447,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchBindColSingleType_
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLINTEGER col = 0;
@@ -507,10 +499,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchBindColSingleType_
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLDOUBLE col = 0.0;
@@ -560,10 +551,9 @@ TEST_F(PerformanceTest, ENABLE_FOR_OPTIMIZED_BUILDS_ONLY(FetchArrayBindColSingle
 
     std::cout << "Executing query:\n\t" << query_orig << std::endl;
 
-    const auto query = fromUTF8<SQLTCHAR>(query_orig);
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>(query_orig);
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
 
     SQLULEN rows_processed = 0;

--- a/driver/test/result_set_reader.hpp
+++ b/driver/test/result_set_reader.hpp
@@ -1,6 +1,7 @@
 #include "driver/test/client_utils.h"
 
 #include <cassert>
+#include <unordered_map>
 
 /**
 * A very simple wrapper around ODBC's SQLFetch and SQLGetData functions.
@@ -38,12 +39,12 @@ public:
         // consistently across the whole code base. For now, I'll stick to this common,
         // yet incorrect, approach.
         // For reference: https://reviews.llvm.org/D138307
-        std::basic_string<SQLTCHAR> input_name(256, '\0');
+        std::basic_string<PTChar> input_name(256, '\0');
         for (SQLSMALLINT idx = 1; idx <= num_columns; ++idx) {
             ODBC_CALL_ON_STMT_THROW(stmt, SQLDescribeCol(
                 stmt,
                 idx,
-                input_name.data(),
+                ptcharCast(input_name.data()),
                 static_cast<SQLSMALLINT>(input_name.size()),
                 &name_length,
                 nullptr,

--- a/driver/test/statement_parameter_bindings_it.cpp
+++ b/driver/test/statement_parameter_bindings_it.cpp
@@ -10,10 +10,9 @@ class StatementParameterBindingsTest
 };
 
 TEST_F(StatementParameterBindingsTest, Missing) {
-    const auto query = fromUTF8<SQLTCHAR>("SELECT isNull(?)");
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>("SELECT isNull(?)");
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecute(hstmt));
     SQLRETURN rc = SQLFetch(hstmt);
 
@@ -47,13 +46,12 @@ TEST_F(StatementParameterBindingsTest, Missing) {
 }
 
 TEST_F(StatementParameterBindingsTest, NoBuffer) {
-    const auto query = fromUTF8<SQLTCHAR>("SELECT isNull(?)");
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>("SELECT isNull(?)");
 
     SQLINTEGER param = 0;
     SQLLEN param_ind = 0;
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
         SQLBindParameter(
             hstmt,
@@ -101,12 +99,11 @@ TEST_F(StatementParameterBindingsTest, NoBuffer) {
 }
 
 TEST_F(StatementParameterBindingsTest, NullValueForInteger) {
-    const auto query = fromUTF8<SQLTCHAR>("SELECT isNull(?)");
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>("SELECT isNull(?)");
 
     SQLLEN param_ind = SQL_NULL_DATA;
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
         SQLBindParameter(
             hstmt,
@@ -146,12 +143,11 @@ TEST_F(StatementParameterBindingsTest, NullValueForInteger) {
 }
 
 TEST_F(StatementParameterBindingsTest, NullValueForString) {
-    const auto query = fromUTF8<SQLTCHAR>("SELECT isNull(?)");
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>("SELECT isNull(?)");
 
     SQLLEN param_ind = SQL_NULL_DATA;
 
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
         SQLBindParameter(
             hstmt,
@@ -197,14 +193,13 @@ class StatementParameterArrayBindingsTest
 };
 
 TEST_F(StatementParameterBindingsTest, IntArray) {
-    const auto query = fromUTF8<SQLTCHAR>("SELECT ?");
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>("SELECT ?");
 
     SQLINTEGER param[] = { 1, 2, 3 };
     SQLLEN param_ind[] = { 0, 0, 0 };
 
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLSetStmtAttr(hstmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)lengthof(param), 0));
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
         SQLBindParameter(
             hstmt,
@@ -256,14 +251,13 @@ TEST_F(StatementParameterBindingsTest, IntArray) {
 }
 
 TEST_F(StatementParameterBindingsTest, StringArray) {
-    const auto query = fromUTF8<SQLTCHAR>("SELECT ?");
-    auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+    auto query = fromUTF8<PTChar>("SELECT ?");
 
     SQLCHAR param[][10] = { "aaa", "bbbb", "ccccc" };
     SQLLEN param_ind[] = { SQL_NTS, 4, SQL_NTS };
 
     ODBC_CALL_ON_STMT_THROW(hstmt, SQLSetStmtAttr(hstmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)lengthof(param), 0));
-    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
     ODBC_CALL_ON_STMT_THROW(hstmt,
         SQLBindParameter(
             hstmt,

--- a/driver/test/statement_parameters_it.cpp
+++ b/driver/test/statement_parameters_it.cpp
@@ -24,22 +24,21 @@ protected:
     }
 
     inline auto execute_with_decimal_as_string(const std::string & initial_str, const std::string & expected_str, bool case_sensitive = true) {
-        const auto query = fromUTF8<SQLTCHAR>("SELECT ?");
-        auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+        auto query = fromUTF8<PTChar>("SELECT ?");
 
         SQLCHAR param[256] = {};
         SQLLEN param_ind = 0;
 
         char * param_ptr = reinterpret_cast<char *>(param);
         ASSERT_LT(initial_str.size(), lengthof(param));
-        std::strncpy(param_ptr, initial_str.c_str(), lengthof(param) - 1);
+        std::strncpy(param_ptr, initial_str.data(), lengthof(param) - 1);
 
         // We need this to autodetect actual precision and scale of the value in initial_str.
         SQL_NUMERIC_STRUCT param_typed;
         value_manip::to_null(param_typed);
         value_manip::from_value<std::string>::template to_value<SQL_NUMERIC_STRUCT>::convert(initial_str, param_typed);
 
-        ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+        ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
         ODBC_CALL_ON_STMT_THROW(hstmt,
             SQLBindParameter(
                 hstmt,
@@ -106,9 +105,9 @@ protected:
         }
 
         if (case_sensitive)
-            ASSERT_STREQ(resulting_str.c_str(), expected_str.c_str());
+            ASSERT_STREQ(resulting_str.data(), expected_str.data());
         else
-            ASSERT_STRCASEEQ(resulting_str.c_str(), expected_str.c_str());
+            ASSERT_STRCASEEQ(resulting_str.data(), expected_str.data());
 
         ASSERT_EQ(SQLFetch(hstmt), SQL_NO_DATA);
     }
@@ -130,8 +129,7 @@ private:
             !std::is_same<T, SQL_NUMERIC_STRUCT>::value
         >::type * = nullptr // T is a struct (except SQL_NUMERIC_STRUCT) or scalar type
     ) {
-        const auto query = fromUTF8<SQLTCHAR>("SELECT ?");
-        auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+        auto query = fromUTF8<PTChar>("SELECT ?");
 
         T param;
         value_manip::to_null(param);
@@ -139,7 +137,7 @@ private:
 
         SQLLEN param_ind = 0;
 
-        ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+        ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
         ODBC_CALL_ON_STMT_THROW(hstmt,
             SQLBindParameter(
                 hstmt,
@@ -189,9 +187,9 @@ private:
         value_manip::from_value<T>::template to_value<std::string>::convert(col, resulting_str);
 
         if (case_sensitive)
-            ASSERT_STREQ(resulting_str.c_str(), expected_str.c_str());
+            ASSERT_STREQ(resulting_str.data(), expected_str.data());
         else
-            ASSERT_STRCASEEQ(resulting_str.c_str(), expected_str.c_str());
+            ASSERT_STRCASEEQ(resulting_str.data(), expected_str.data());
 
         ASSERT_EQ(SQLFetch(hstmt), SQL_NO_DATA);
     }
@@ -202,8 +200,7 @@ private:
             std::is_same<T, SQL_NUMERIC_STRUCT>::value
         >::type * = nullptr // T is SQL_NUMERIC_STRUCT
     ) {
-        const auto query = fromUTF8<SQLTCHAR>("SELECT ?");
-        auto * query_wptr = const_cast<SQLTCHAR * >(query.c_str());
+        auto query = fromUTF8<PTChar>("SELECT ?");
 
         T param;
         value_manip::to_null(param);
@@ -211,7 +208,7 @@ private:
 
         SQLLEN param_ind = 0;
 
-        ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, query_wptr, SQL_NTS));
+        ODBC_CALL_ON_STMT_THROW(hstmt, SQLPrepare(hstmt, ptcharCast(query.data()), SQL_NTS));
         ODBC_CALL_ON_STMT_THROW(hstmt,
             SQLBindParameter(
                 hstmt,
@@ -267,9 +264,9 @@ private:
         value_manip::from_value<T>::template to_value<std::string>::convert(col, resulting_str);
 
         if (case_sensitive)
-            ASSERT_STREQ(resulting_str.c_str(), expected_str.c_str());
+            ASSERT_STREQ(resulting_str.data(), expected_str.data());
         else
-            ASSERT_STRCASEEQ(resulting_str.c_str(), expected_str.c_str());
+            ASSERT_STRCASEEQ(resulting_str.data(), expected_str.data());
 
         ASSERT_EQ(SQLFetch(hstmt), SQL_NO_DATA);
     }

--- a/driver/utils/conversion.h
+++ b/driver/utils/conversion.h
@@ -10,14 +10,111 @@
 
 #include <cstring>
 
-using CharTypeLPCTSTR = std::remove_cv_t<std::remove_pointer_t<LPCTSTR>>;
+/***********************************************************************************************************************
+// All ODBC functions expect strings to be passed as pointers to unsigned character types:
+// either `unsigned char` for ANSI functions or `unsigned short` for Unicode functions.
+// This is inconvenient when writing C++ code, as we typically use std::string and std::u16string.
+// Using std::basic_string<unsigned char> or std::basic_string<unsigned short> is both verbose and generally
+// discouraged. For example, libc++ removed `std::char_traits` specializations for such character types.
+//
+// Therefore, it is easier to use standard C++ string types and cast from signed character pointers (e.g., char*) to
+// unsigned ones (e.g., SQLCHAR*) only when calling ODBC functions.
+//
+// The purpose of the code below is to define a universal approach for creating and passing strings to ODBC functions:
+//
+//     // 1. Create a string, either `std::string` or `std::u16string`, depending on whether UNICODE is defined
+//     auto query = fromUTF8<PTChar>("SELECT VERSION();");
+//
+//     // 2. Call an ODBC function, passing a pointer to the data converted to the expected type
+//     SQLExecDirect(stmt, asSqlTChar(query.data()), SQL_NTS);
+//
+***********************************************************************************************************************/
 
+// PTChar - Portable Text Char.
+// It is similar to SQLTCHAR (SQL Text CHARacter), but instead of using unsigned types, which are not well-supported
+// by the C++ standard, it is defined in terms of well-defined signed types.
+#ifdef UNICODE
+    using PTChar = char16_t;   // then std::basic_string<PTChar> is the same as std::u16string
+#else
+    using PTChar = char;       // then std::basic_string<PTChar> is the same as std::string
+#endif
+
+// Map each signed char types with ODBC's unsigned char types
+template <typename C>
+struct AsSqlCharTextConversionTrait
+{
+};
+
+template <>
+struct AsSqlCharTextConversionTrait<char>
+{
+    using type = SQLCHAR;
+};
+
+template <>
+struct AsSqlCharTextConversionTrait<char16_t>
+{
+    using type = SQLWCHAR;
+};
+
+// Cast C++ string character pointer types (i.e. char * and char16_t *) to ODBC's unsigned pointer types,
+// i.e. SQLCHAR* and SQLTCHAR*. In essence it is just a reinterpret_cast, however it prevents incorrect conversions
+// and does not allow conversions to arbitrary types.
+// In short, char* will always be converted to SQLCHAR*, and char16_t* will always be converted to SQLWCHAR*.
+template <typename C>
+constexpr auto ptcharCast(C * str)
+{
+    // Make sure that const and volatile are preserved
+    using T = typename AsSqlCharTextConversionTrait<std::remove_cv_t<C>>::type;
+    using VolatileT = typename std::conditional_t<std::is_volatile_v<C>, volatile T, T>;
+    using ConstVolatileT = typename std::conditional_t<std::is_const_v<C>, const VolatileT, VolatileT>;
+
+    static_assert(sizeof(T) == sizeof(C));
+    return reinterpret_cast<ConstVolatileT *>(str);
+}
+
+// The situation is complicated for Windows string types, such as LPSTR, LPCSTR, LPWSTR, etc.
+// For comparison, ODBC types, such as SQLCHAR, SQLWCHAR, are always unsigned, however
+// Windows' LPSTR, LPWSTR, etc. do not have this property:
+//  - LPSTR, aka Long Pointer STRing is a `char*`;
+//  - LPWSTR, aka Long Pointer Wide STRing, is `wchar_t *` on windows and `unsigned short*` on unixODBC.
+//  - The LPTSTR alias, aka Long Pointer Text STRing, is `unsigned short*` when UNICODE is defined
+//    otherwise `unsigned char*` -- that is different than LPSTR and LPWSTR.
+// We need a portable type to which we can convert the content of our `std::basic_string<PTChar>`
+// when calling Windows functions, such as SQLGetPrivateProfileString, SQLWriteDSNToIni, etc.
+// That is what WinTChar for. The idea is to use `std::basic_string<PTChar>` and then cast its content
+// to `WinTChar*` when calling such Windows functions.
+#ifdef UNICODE
+    using  WinTChar = std::remove_pointer_t<LPWSTR>;
+#else
+    using WinTChar = std::remove_pointer_t<LPSTR>;
+#endif
+
+// A slightly safer version of reinterpret_cast that prevents casting pointers to pointers of a different size.
+// This prevents from incorrectly converting string pointers, for example std::string::data() to `unsigned short*`, when
+// calling an ODBC function.
+template <typename Out, typename In>
+constexpr Out* arrayPtrCast(In * in)
+{
+    static_assert(sizeof(In) == sizeof(Out));
+    return reinterpret_cast<Out*>(in);
+}
+
+/***********************************************************************************************************************
+// UTF Conversion Functions
+***********************************************************************************************************************/
 
 // stringBufferLength() - return the number of elements in the null-terminated buffer (that is assumed to hold a string).
 
 template <typename CharType>
 inline std::size_t stringBufferLength(const CharType * str) {
     return (str ? std::basic_string_view<CharType>{str}.size() + 1 : 0);
+}
+
+template <>
+inline std::size_t stringBufferLength<SQLTCHAR>(const SQLTCHAR * str) {
+    static_assert(sizeof(SQLTCHAR) == sizeof(PTChar)); // Helps noticing stupid refactoring mistakes
+    return stringBufferLength(reinterpret_cast<const PTChar*>(str));
 }
 
 template <typename CharType>

--- a/driver/utils/conversion_icu.h
+++ b/driver/utils/conversion_icu.h
@@ -48,11 +48,6 @@ namespace value_manip {
         struct to_application {
             static inline void convert(const SourceType & src, DestinationType & dest); // Leave unimplemented for general case.
         };
-
-        template <typename DestinationType>
-        struct to_data_source {
-            static inline void convert(const SourceType & src, DestinationType & dest); // Leave unimplemented for general case.
-        };
     };
 
     template <typename SourceType>
@@ -63,7 +58,7 @@ namespace value_manip {
         };
     };
 
-    template <typename SourceCharType> // SQLCHAR or SQLWCHAR
+    template <typename SourceCharType> // char or char16_t
     struct from_application<SourceCharType *> {
         template <typename DestinationType>
         struct to_driver {
@@ -154,14 +149,9 @@ namespace value_manip {
         struct to_application {
             static inline void convert(const SourceType & src, DestinationType & dest); // Leave unimplemented for general case.
         };
-
-        template <typename DestinationType>
-        struct to_data_source {
-            static inline void convert(const SourceType & src, DestinationType & dest); // Leave unimplemented for general case.
-        };
     };
 
-    template <typename DestinationCharType> // SQLCHAR or SQLWCHAR
+    template <typename DestinationCharType> // char or char16_t
     struct from_driver<std::basic_string<DriverPivotNarrowCharType>>::to_application<DestinationCharType *> {
         using DestinationType = std::basic_string<DestinationCharType>;
 
@@ -336,6 +326,12 @@ inline auto toUTF8(const CharType * src, SQLLEN src_length, UnicodeConversionCon
     return dest;
 }
 
+template <>
+inline auto toUTF8<SQLTCHAR>(const SQLTCHAR * src, SQLLEN src_length, UnicodeConversionContext & context) {
+    static_assert(sizeof(SQLTCHAR) == sizeof(PTChar)); // Helps noticing stupid refactoring mistakes
+    return toUTF8(reinterpret_cast<const PTChar*>(src), src_length, context);
+}
+
 template <typename CharType>
 inline auto toUTF8(const CharType * src, UnicodeConversionContext & context) {
     return toUTF8(src, SQL_NTS, context);
@@ -432,3 +428,4 @@ template <typename CharType>
 inline void fromUTF8(const DriverPivotNarrowCharType * src, std::basic_string<CharType> & dest) {
     return fromUTF8<CharType>(src, SQL_NTS, dest);
 }
+

--- a/driver/utils/resize_without_initialization.h
+++ b/driver/utils/resize_without_initialization.h
@@ -5,11 +5,5 @@
 #include <folly/memory/UninitializedMemoryHacks.h>
 #define resize_without_initialization(container, size) folly::resizeWithoutInitialization(container, size)
 
-//FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(char)
-FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(signed char)
-FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(unsigned char)
-//FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(char8_t)
 FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(char16_t)
 FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(char32_t)
-//FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(wchar_t)
-FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(unsigned short)

--- a/driver/utils/string_pool.h
+++ b/driver/utils/string_pool.h
@@ -9,13 +9,9 @@ class StringPool {
 public:
     explicit StringPool(const std::size_t max_size)
         : string_pool_c_   {max_size}
-        , string_pool_sc_  {max_size}
-        , string_pool_uc_  {max_size}
-//      , string_pool_c8_  {max_size}
         , string_pool_c16_ {max_size}
         , string_pool_c32_ {max_size}
         , string_pool_wc_  {max_size}
-        , string_pool_us_  {max_size}
     {
     }
 
@@ -30,13 +26,9 @@ private:
     inline ObjectPool<std::basic_string<CharType>> & accessStringPool(); // Leave unimplemented for general case.
 
     ObjectPool< std::basic_string<char>           > string_pool_c_;
-    ObjectPool< std::basic_string<signed char>    > string_pool_sc_;
-    ObjectPool< std::basic_string<unsigned char>  > string_pool_uc_;
-//  ObjectPool< std::basic_string<char8_t>        > string_pool_c8_;
     ObjectPool< std::basic_string<char16_t>       > string_pool_c16_;
     ObjectPool< std::basic_string<char32_t>       > string_pool_c32_;
     ObjectPool< std::basic_string<wchar_t>        > string_pool_wc_;
-    ObjectPool< std::basic_string<unsigned short> > string_pool_us_;
 };
 
 template <typename CharType>
@@ -55,23 +47,6 @@ inline ObjectPool<std::basic_string<char>> & StringPool::accessStringPool<char>(
 }
 
 template <>
-inline ObjectPool<std::basic_string<signed char>> & StringPool::accessStringPool<signed char>() {
-    return string_pool_sc_;
-}
-
-template <>
-inline ObjectPool<std::basic_string<unsigned char>> & StringPool::accessStringPool<unsigned char>() {
-    return string_pool_uc_;
-}
-
-/*
-template <>
-inline ObjectPool<std::basic_string<char8_t>> & StringPool::accessStringPool<char8_t>() {
-    return string_pool_c8_;
-}
-*/
-
-template <>
 inline ObjectPool<std::basic_string<char16_t>> & StringPool::accessStringPool<char16_t>() {
     return string_pool_c16_;
 }
@@ -84,9 +59,4 @@ inline ObjectPool<std::basic_string<char32_t>> & StringPool::accessStringPool<ch
 template <>
 inline ObjectPool<std::basic_string<wchar_t>> & StringPool::accessStringPool<wchar_t>() {
     return string_pool_wc_;
-}
-
-template <>
-inline ObjectPool<std::basic_string<unsigned short>> & StringPool::accessStringPool<unsigned short>() {
-    return string_pool_us_;
 }

--- a/driver/utils/type_info.cpp
+++ b/driver/utils/type_info.cpp
@@ -2,6 +2,7 @@
 
 #include <Poco/String.h>
 #include <stdexcept>
+#include <unordered_map>
 
 const TypeInfo* typeInfoIfExistsFor(const std::string & type) {
     static const auto types = [](){

--- a/driver/utils/type_info.h
+++ b/driver/utils/type_info.h
@@ -1516,8 +1516,8 @@ namespace value_manip {
     };
 
     template <>
-    struct from_value<SQLCHAR *> {
-        using SourceType = SQLCHAR *;
+    struct from_value<char *> {
+        using SourceType = char *;
 
         template <typename DestinationType>
         struct to_value {
@@ -1528,7 +1528,7 @@ namespace value_manip {
     };
 
     template <>
-    struct from_value<SQLCHAR *>::to_value<std::string> {
+    struct from_value<char *>::to_value<std::string> {
         using DestinationType = std::string;
 
         static inline void convert(const SourceType & src, DestinationType & dest) {
@@ -1537,8 +1537,8 @@ namespace value_manip {
     };
 
     template <>
-    struct from_value<SQLWCHAR *> {
-        using SourceType = SQLWCHAR *;
+    struct from_value<char16_t *> {
+        using SourceType = char16_t *;
 
         template <typename DestinationType>
         struct to_value {
@@ -1549,7 +1549,7 @@ namespace value_manip {
     };
 
     template <>
-    struct from_value<SQLWCHAR *>::to_value<std::string> {
+    struct from_value<char16_t *>::to_value<std::string> {
         using DestinationType = std::string;
 
         static inline void convert(const SourceType & src, DestinationType & dest) {
@@ -2070,8 +2070,8 @@ namespace value_manip {
     };
 
     template <>
-    struct to_buffer<SQLCHAR *> {
-        using DestinationType = SQLCHAR *;
+    struct to_buffer<char *> {
+        using DestinationType = char *;
 
         template <typename SourceType>
         struct from_value {
@@ -2081,24 +2081,24 @@ namespace value_manip {
                     *dest.indicator = 0; // (Null) indicator pointer of the binding. Value is not null here so we store 0 in it.
 
                 if constexpr (std::is_same_v<SourceType, std::string>) {
-                    return fillOutputString<SQLCHAR>(src, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
+                    return fillOutputString<char>(src, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
                 }
                 else if constexpr (is_string_data_source_type_v<SourceType>) {
-                    return fillOutputString<SQLCHAR>(src.value, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
+                    return fillOutputString<char>(src.value, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
                 }
                 else {
                     std::string dest_obj;
                     to_null(dest_obj);
                     ::value_manip::from_value<SourceType>::template to_value<std::string>::convert(src, dest_obj);
-                    return fillOutputString<SQLCHAR>(dest_obj, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
+                    return fillOutputString<char>(dest_obj, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
                 }
             }
         };
     };
 
     template <>
-    struct to_buffer<SQLWCHAR *> {
-        using DestinationType = SQLWCHAR *;
+    struct to_buffer<char16_t *> {
+        using DestinationType = char16_t *;
 
         template <typename SourceType>
         struct from_value {
@@ -2108,16 +2108,16 @@ namespace value_manip {
                     *dest.indicator = 0; // (Null) indicator pointer of the binding. Value is not null here so we store 0 in it.
 
                 if constexpr (std::is_same_v<SourceType, std::string>) {
-                    return fillOutputString<SQLWCHAR>(src, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
+                    return fillOutputString<char16_t>(src, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
                 }
                 else if constexpr (is_string_data_source_type_v<SourceType>) {
-                    return fillOutputString<SQLWCHAR>(src.value, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
+                    return fillOutputString<char16_t>(src.value, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
                 }
                 else {
                     std::string dest_obj;
                     to_null(dest_obj);
                     ::value_manip::from_value<SourceType>::template to_value<std::string>::convert(src, dest_obj);
-                    return fillOutputString<SQLWCHAR>(dest_obj, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
+                    return fillOutputString<char16_t>(dest_obj, dest.value, dest.value_max_size, dest.value_size, true, std::forward<ConversionContext>(context));
                 }
             }
         };
@@ -2199,8 +2199,8 @@ namespace value_manip {
     };
 
     template <>
-    struct from_buffer<SQLCHAR *> {
-        using SourceType = SQLCHAR *;
+    struct from_buffer<char *> {
+        using SourceType = char *;
 
         template <typename DestinationType>
         struct to_value {
@@ -2210,7 +2210,7 @@ namespace value_manip {
                     return;
                 }
 
-                const auto * cstr = reinterpret_cast<const SQLCHAR *>(src.value);
+                const auto * cstr = reinterpret_cast<const char *>(src.value);
                 const auto * sz_ptr = src.value_size;
                 const auto * ind_ptr = src.indicator;
 
@@ -2252,8 +2252,8 @@ namespace value_manip {
     };
 
     template <>
-    struct from_buffer<SQLWCHAR *> {
-        using SourceType = SQLWCHAR *;
+    struct from_buffer<char16_t *> {
+        using SourceType = char16_t *;
 
         template <typename DestinationType>
         struct to_value {
@@ -2263,7 +2263,7 @@ namespace value_manip {
                     return;
                 }
 
-                const auto * cstr = reinterpret_cast<const SQLWCHAR *>(src.value);
+                const auto * cstr = reinterpret_cast<const char16_t *>(src.value);
                 const auto * sz_ptr = src.value_size;
                 const auto * ind_ptr = src.indicator;
 
@@ -2367,6 +2367,8 @@ namespace value_manip {
 } // namespace value_manip
 
 template <typename T> constexpr inline SQLSMALLINT getCTypeFor(); // leave unimplemented for general case
+template <> constexpr inline SQLSMALLINT getCTypeFor< char *               >() { return SQL_C_CHAR;           }
+template <> constexpr inline SQLSMALLINT getCTypeFor< char16_t *           >() { return SQL_C_WCHAR;          }
 template <> constexpr inline SQLSMALLINT getCTypeFor< SQLCHAR *            >() { return SQL_C_CHAR;           }
 template <> constexpr inline SQLSMALLINT getCTypeFor< SQLWCHAR *           >() { return SQL_C_WCHAR;          }
 template <> constexpr inline SQLSMALLINT getCTypeFor< SQLSCHAR             >() { return SQL_C_STINYINT;       }
@@ -2422,8 +2424,8 @@ inline auto getCTypeOctetLength(SQLSMALLINT c_type) {
 template <typename T>
 inline auto readReadyDataTo(const BindingInfo & src, T & dest) {
     switch (src.c_type) {
-        case SQL_C_CHAR:           return value_manip::from_buffer< SQLCHAR *            >::template to_value< T >::convert(src, dest);
-        case SQL_C_WCHAR:          return value_manip::from_buffer< SQLWCHAR *           >::template to_value< T >::convert(src, dest);
+        case SQL_C_CHAR:           return value_manip::from_buffer< char *               >::template to_value< T >::convert(src, dest);
+        case SQL_C_WCHAR:          return value_manip::from_buffer< char16_t *           >::template to_value< T >::convert(src, dest);
         case SQL_C_BIT:            return value_manip::from_buffer< SQLCHAR              >::template to_value< T >::convert(src, dest);
         case SQL_C_TINYINT:        return value_manip::from_buffer< SQLSCHAR             >::template to_value< T >::convert(src, dest);
         case SQL_C_STINYINT:       return value_manip::from_buffer< SQLSCHAR             >::template to_value< T >::convert(src, dest);
@@ -2438,7 +2440,7 @@ inline auto readReadyDataTo(const BindingInfo & src, T & dest) {
         case SQL_C_UBIGINT:        return value_manip::from_buffer< SQLUBIGINT           >::template to_value< T >::convert(src, dest);
         case SQL_C_FLOAT:          return value_manip::from_buffer< SQLREAL              >::template to_value< T >::convert(src, dest);
         case SQL_C_DOUBLE:         return value_manip::from_buffer< SQLDOUBLE            >::template to_value< T >::convert(src, dest);
-        case SQL_C_BINARY:         return value_manip::from_buffer< SQLCHAR *            >::template to_value< T >::convert(src, dest);
+        case SQL_C_BINARY:         return value_manip::from_buffer< char *               >::template to_value< T >::convert(src, dest);
         case SQL_C_GUID:           return value_manip::from_buffer< SQLGUID              >::template to_value< T >::convert(src, dest);
 
 //      case SQL_C_BOOKMARK:       return value_manip::from_buffer< BOOKMARK             >::template to_value< T >::convert(src, dest);
@@ -2463,8 +2465,8 @@ inline auto readReadyDataTo(const BindingInfo & src, T & dest) {
 template <typename T, typename ConversionContext>
 inline auto writeDataFrom(const T & src, BindingInfo & dest, ConversionContext && context) {
     switch (dest.c_type) {
-        case SQL_C_CHAR:           return value_manip::to_buffer< SQLCHAR *            >::template from_value< T >::convert(src, dest, std::forward<ConversionContext>(context));
-        case SQL_C_WCHAR:          return value_manip::to_buffer< SQLWCHAR *           >::template from_value< T >::convert(src, dest, std::forward<ConversionContext>(context));
+        case SQL_C_CHAR:           return value_manip::to_buffer< char *               >::template from_value< T >::convert(src, dest, std::forward<ConversionContext>(context));
+        case SQL_C_WCHAR:          return value_manip::to_buffer< char16_t *           >::template from_value< T >::convert(src, dest, std::forward<ConversionContext>(context));
         case SQL_C_BIT:            return value_manip::to_buffer< SQLCHAR              >::template from_value< T >::convert(src, dest);
         case SQL_C_TINYINT:        return value_manip::to_buffer< SQLSCHAR             >::template from_value< T >::convert(src, dest);
         case SQL_C_STINYINT:       return value_manip::to_buffer< SQLSCHAR             >::template from_value< T >::convert(src, dest);
@@ -2479,7 +2481,7 @@ inline auto writeDataFrom(const T & src, BindingInfo & dest, ConversionContext &
         case SQL_C_UBIGINT:        return value_manip::to_buffer< SQLUBIGINT           >::template from_value< T >::convert(src, dest);
         case SQL_C_FLOAT:          return value_manip::to_buffer< SQLREAL              >::template from_value< T >::convert(src, dest);
         case SQL_C_DOUBLE:         return value_manip::to_buffer< SQLDOUBLE            >::template from_value< T >::convert(src, dest);
-        case SQL_C_BINARY:         return value_manip::to_buffer< SQLCHAR *            >::template from_value< T >::convert(src, dest, std::forward<ConversionContext>(context));
+        case SQL_C_BINARY:         return value_manip::to_buffer< char *               >::template from_value< T >::convert(src, dest, std::forward<ConversionContext>(context));
         case SQL_C_GUID:           return value_manip::to_buffer< SQLGUID              >::template from_value< T >::convert(src, dest);
 
 //      case SQL_C_BOOKMARK:       return value_manip::to_buffer< BOOKMARK             >::template from_value< T >::convert(src, dest);


### PR DESCRIPTION
ODBC API requires strings to be passed as pointers to arrays of unsigned char and unsigned short. This led the design, and especially the tests, to use std::basic_string instantiations that are not allowed by the C++ standard. This prevents updating libc++ to a newer version, because libc++ has removed all non-standard specializations. The only specializations that remain are for char, wchar_t, char8_t, char16_t, and char32_t.

This change removes all uses of non-standard instantiations of std::basic_string, i.e., std::basic_string<SQLCHAR> and std::basic_string<SQLWCHAR>, and replaces them with the standard std::string and std::u16string. For portability, char and char16_t are aliased by PTChar (portable text character), which is a typedef that depends on the type of the build (UNICODE or ANSI). The content of the string can then be converted to the expected type when calling ODBC functions using the ptcharCast function, which ensures that the data is always converted correctly.

Most of the changes involve replacing SQLTCHAR with PTChar and converting the strings when calling ODBC functions. These conversions mostly happen in the tests and not in the driver itself.