### PR TITLE
Quick fix for CH ODBC with MS Access #275

### DIFF
--- a/driver/api/odbc.cpp
+++ b/driver/api/odbc.cpp
@@ -948,6 +948,11 @@ SQLRETURN SQL_API EXPORTED_FUNCTION_MAYBE_W(SQLTables)(
                     query << ")";
                 }
             }
+
+            if (!catalog.empty() && catalog != "%") {
+                query << " AND database = '" << escapeForSQL(catalog) << "'";
+            }
+            
         }
 
         query << " ORDER BY TABLE_TYPE, TABLE_CAT, TABLE_SCHEM, TABLE_NAME";


### PR DESCRIPTION
This pull request enhances the ODBC driver by improving support for specific SQL functions and adding query-building logic for new functionality. The most important changes include enabling previously unsupported SQL APIs, adding query logic for `SQLSpecialColumns` and `SQLStatistics`, and refining query filtering for catalog and table information.

### Enhancements to SQL API Support:
* Enabled support for `SQL_API_SQLSPECIALCOLUMNS` and `SQL_API_SQLSTATISTICS` by uncommenting their definitions in `SQLGetFunctions`. This allows the driver to declare support for these APIs.

### Query Logic Additions:
* Implemented query-building logic for `SQLSpecialColumns`, including a placeholder query that returns an empty result set with the expected schema. This ensures compatibility with applications expecting this API.
* Added query-building logic for `SQLStatistics` to retrieve index and statistics information from `system.data_skipping_indices`. The query includes filters for catalog and table names, ensuring accurate results based on input parameters.

### Query Filtering Improvements:
* Enhanced `SQLTables` to filter results by catalog name when provided, improving the specificity of returned data.