### PR TITLE
No EOF check after zero bytes received

### DIFF
--- a/contrib/poco/Net/src/HTTPChunkedStream.cpp
+++ b/contrib/poco/Net/src/HTTPChunkedStream.cpp
@@ -138,7 +138,7 @@ int HTTPChunkedStreamBuf::readChar()
 	char buffer = 0;
 	int n = _session.read(&buffer, 1);
 
-	if (n == 0 && _session.peek() == eof) {
+	if (n == 0) {
 		throw IncompleteChunkedTransfer();
 	}
 
@@ -222,7 +222,7 @@ int HTTPChunkedStreamBuf::readChunkEncodedStream(char* buffer, std::streamsize l
 
 		if (n > 0) _chunk -= n;
 
-		if (n == 0 && _session.peek() == eof) {
+		if (n == 0 && length > 0) {
 			throw IncompleteChunkedTransfer();
 		}
 


### PR DESCRIPTION
When we receive zero bytes, we already know that this is EOF, an extra check can attempt to read from the socket leading to timeout on Windows