### PR TITLE
Increase prefetch size to 32 KB

### DIFF
--- a/driver/utils/amortized_istream_reader.h
+++ b/driver/utils/amortized_istream_reader.h
@@ -87,7 +87,7 @@ private:
         const auto avail = available();
 
         if (avail < count) {
-            static constexpr std::size_t min_read_size = 1 << 13; // 8 KB
+            static constexpr std::size_t min_read_size = 32768;
 
             const auto to_read = std::max<std::size_t>(min_read_size, count - avail);
             const auto tail_capacity = buffer_.capacity() - buffer_.size();


### PR DESCRIPTION
The ring buffer used to check for ClickHouse exceptions, implemented in `contrib/poco/Net/src/HTTPChunkedStream.cpp`, has a size of 32 KB. In case of an abrupt connection close without properly ending the chunked encoded stream, `HTTPChunkedStream` searches the last 32 KB for exceptions. However, this is not very effective if the `AmortizedIStreamReader` prefetches only 8 KB of data. This change increases the prefetch size to 32 KB.