### PR TITLE
Set cast_keep_nullable enabled for all queries

### DIFF
--- a/driver/connection.cpp
+++ b/driver/connection.cpp
@@ -94,6 +94,7 @@ Poco::URI Connection::getUri() const {
     bool default_format_set = false;
     bool session_id_set = false;
     bool enable_http_compression_set = false;
+    bool cast_keep_nullable_set = false;
 
     for (const auto& parameter : uri.getQueryParameters()) {
         if (Poco::UTF8::icompare(parameter.first, "default_format") == 0) {
@@ -107,6 +108,9 @@ Poco::URI Connection::getUri() const {
         }
         else if (Poco::UTF8::icompare(parameter.first, "enable_http_compression") == 0 && !parameter.second.empty()) {
             enable_http_compression_set = true;
+        }
+        else if (Poco::UTF8::icompare(parameter.first, "cast_keep_nullable") == 0 && !parameter.second.empty()) {
+            cast_keep_nullable_set = true;
         }
     }
 
@@ -125,6 +129,10 @@ Poco::URI Connection::getUri() const {
     // Add http compression parameter, but only if the parameter is not already defined in the URI
     if (enable_http_compression && !enable_http_compression_set) {
         uri.addQueryParameter("enable_http_compression", enable_http_compression ? "1" : "0");
+    }
+
+    if (!cast_keep_nullable_set) {
+        uri.addQueryParameter("cast_keep_nullable", "1");
     }
 
     return uri;

--- a/driver/test/misc_it.cpp
+++ b/driver/test/misc_it.cpp
@@ -28,6 +28,33 @@ TEST_F(MiscellaneousTest, GetDatabaseVersion) {
     ASSERT_EQ(param_version, query_version);
 }
 
+TEST_F(MiscellaneousTest, CastKeepNullable) {
+    auto query = fromUTF8<PTChar>(R"(
+        SELECT sum(CAST(value, 'UInt64'))
+        FROM
+        (
+            SELECT 42 AS value
+            UNION ALL
+            SELECT NULL AS value
+        ))");
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLExecDirect(hstmt, ptcharCast(query.data()), SQL_NTS));
+
+    SQLINTEGER out = 0;
+    SQLLEN out_len = 0;
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLFetch(hstmt));
+    ODBC_CALL_ON_STMT_THROW(hstmt, SQLGetData(
+        hstmt,
+        1,
+        getCTypeFor<SQLINTEGER>(),
+        &out,
+        sizeof(out),
+        &out_len
+    ));
+
+    ASSERT_EQ(out_len, sizeof(out));
+    ASSERT_EQ(out, 42);
+}
+
 TEST_F(MiscellaneousTest, RowArraySizeAttribute) {
     SQLRETURN rc = SQL_SUCCESS;
     SQLULEN size = 0;


### PR DESCRIPTION
Fixes:
- https://github.com/ClickHouse/clickhouse-odbc/issues/488
- https://github.com/ClickHouse/clickhouse-odbc/issues/502
