### PR TITLE
Disable UserAgentTest

### DIFF
--- a/driver/test/misc_it.cpp
+++ b/driver/test/misc_it.cpp
@@ -334,7 +334,7 @@ INSTANTIATE_TEST_SUITE_P(CustomUserAgentParams, CustomClientName, ::testing::Val
     std::make_tuple(std::nullopt, "")
 ));
 
-TEST_P(CustomClientName, UserAgentTest) {
+TEST_P(CustomClientName, DISABLED_UserAgentTest) {
     using namespace std::chrono_literals;
     using std::chrono::high_resolution_clock;
 


### PR DESCRIPTION
The UserAgent integration test has long been a source of problems due to recurring issues with system.query_log and differing configurations across environments. The benefits of this test no longer justify the number of issues it causes in CI, so for now, I am disabling it. We need to come up with a better strategy for this kind of testing—probably by using a mock HTTP server, as is done for error handling.