### PR TITLE
Implement proper support for Bool type

### DIFF
--- a/driver/format/ODBCDriver2.cpp
+++ b/driver/format/ODBCDriver2.cpp
@@ -130,6 +130,7 @@ void ODBCDriver2ResultSet::readValue(Field & dest, ColumnInfo & column_info) {
     if (convert_on_fetch_conservatively) switch (column_info.type_without_parameters_id) {
         case DataSourceTypeId::FixedString: readValueAs<DataSourceType< DataSourceTypeId::FixedString >>(value, dest, column_info); break;
         case DataSourceTypeId::String:      readValueAs<DataSourceType< DataSourceTypeId::String      >>(value, dest, column_info); break;
+        case DataSourceTypeId::Bool:        readValueAs<DataSourceType< DataSourceTypeId::Bool        >>(value, dest, column_info); break;
         default:                            readValueAs<WireTypeAnyAsString                            >(value, dest, column_info); break;
     }
     else switch (column_info.type_without_parameters_id) {
@@ -203,6 +204,18 @@ void ODBCDriver2ResultSet::readValue(std::string & src, DataSourceType<DataSourc
 
 void ODBCDriver2ResultSet::readValue(std::string & src, DataSourceType<DataSourceTypeId::Float64> & dest, ColumnInfo & column_info) {
     return value_manip::from_value<std::string>::template to_value<DataSourceType<DataSourceTypeId::Float64>>::convert(src, dest);
+}
+
+void ODBCDriver2ResultSet::readValue(std::string & src, DataSourceType<DataSourceTypeId::Bool> & dest, ColumnInfo & column_info) {
+    if (src == "true") {
+        dest.value = 1;
+        return;
+    }
+    else if (src == "false") {
+        dest.value = 0;
+        return;
+    }
+    value_manip::from_value<std::string>::template to_value<DataSourceType<DataSourceTypeId::Bool>>::convert(src, dest);
 }
 
 void ODBCDriver2ResultSet::readValue(std::string & src, DataSourceType<DataSourceTypeId::Int8> & dest, ColumnInfo & column_info) {

--- a/driver/format/ODBCDriver2.h
+++ b/driver/format/ODBCDriver2.h
@@ -46,6 +46,7 @@ private:
     void readValue(std::string & src, DataSourceType< DataSourceTypeId::FixedString > & dest, ColumnInfo & column_info);
     void readValue(std::string & src, DataSourceType< DataSourceTypeId::Float32     > & dest, ColumnInfo & column_info);
     void readValue(std::string & src, DataSourceType< DataSourceTypeId::Float64     > & dest, ColumnInfo & column_info);
+    void readValue(std::string & src, DataSourceType< DataSourceTypeId::Bool        > & dest, ColumnInfo & column_info);
     void readValue(std::string & src, DataSourceType< DataSourceTypeId::Int8        > & dest, ColumnInfo & column_info);
     void readValue(std::string & src, DataSourceType< DataSourceTypeId::Int16       > & dest, ColumnInfo & column_info);
     void readValue(std::string & src, DataSourceType< DataSourceTypeId::Int32       > & dest, ColumnInfo & column_info);

--- a/driver/result_set.h
+++ b/driver/result_set.h
@@ -50,6 +50,7 @@ public:
         DataSourceType< DataSourceTypeId::FixedString >,
         DataSourceType< DataSourceTypeId::Float32     >,
         DataSourceType< DataSourceTypeId::Float64     >,
+        DataSourceType< DataSourceTypeId::Bool        >,
         DataSourceType< DataSourceTypeId::Int8        >,
         DataSourceType< DataSourceTypeId::Int16       >,
         DataSourceType< DataSourceTypeId::Int32       >,

--- a/driver/test/type_info_it.cpp
+++ b/driver/test/type_info_it.cpp
@@ -32,7 +32,7 @@ TEST_F(TypeInfoTest, ClickhouseToSQLTypeMapping)
     };
 
     std::vector<TypeMappingTestEntry> types = {
-        {"Bool", "0", SQL_VARCHAR},
+        {"Bool", "0", SQL_BIT},
         {"Int8", "0", SQL_TINYINT},
         {"UInt8", "0", SQL_TINYINT},
         {"Int16", "0", SQL_SMALLINT},
@@ -221,6 +221,7 @@ TEST_F(TypeInfoTest, SQLGetTypeInfoResultSet)
     //                  ODBC                            pre/suffix create  unsi-  min/max                 date
     //   type name      data type             size      params     params  gned   scale    sql data type  sub  radix
         {{"Nothing",    SQL_TYPE_NULL     }, {1,        na,  na,   na,     na,    na, na,  SQL_TYPE_NULL, na,  na,  }},
+        {{"Bool",       SQL_BIT           }, {1,        na,  na,   na,     na,    na, na,  SQL_BIT,       na,  na,  }},
         {{"Int8",       SQL_TINYINT       }, {4,        na,  na,   na,     false, na, na,  SQL_TINYINT,   na,  10,  }},
         {{"UInt8",      SQL_TINYINT       }, {3,        na,  na,   na,     true,  na, na,  SQL_TINYINT,   na,  10,  }},
         {{"Int16",      SQL_SMALLINT      }, {6,        na,  na,   na,     false, na, na,  SQL_SMALLINT,  na,  10,  }},
@@ -397,8 +398,7 @@ TEST_F(TypeInfoTest, AllTypesColumns)
     {"DateTime64",     {SQL_TYPE_TIMESTAMP,"DateTime64",  29,  0,   3,    na,    false, SQL_DATE,     3,   16  }},
     {"DateTime64(9)",  {SQL_TYPE_TIMESTAMP,"DateTime64",  29,  0,   9,    na,    false, SQL_DATE,     3,   16  }},
     {"UUID",           {SQL_GUID,          "UUID",        35,  0,   na,   na,    false, SQL_GUID,     na,  16  }},
-    // Bool is currently converted to a string ("true" or "false")
-    {"Bool",           {SQL_VARCHAR,       "String",      msz, 0,   na,   na,    false, SQL_VARCHAR,  na,  msz }},
+    {"Bool",           {SQL_BIT,           "Bool",        1,   0,   na,   na,    false, SQL_BIT,      na,  1   }},
     };
     // clang-format on
 

--- a/driver/utils/type_info.h
+++ b/driver/utils/type_info.h
@@ -16,6 +16,7 @@
 
 enum class DataSourceTypeId {
     Nothing,
+    Bool,
     Int8,
     UInt8,
     Int16,
@@ -150,6 +151,8 @@ public:
     const auto string_max_size = TypeInfo::string_max_size;
     std::array<TypeInfo, total_visible_types> types = {{
         {.type_id=Nothing, .type_name="Nothing", .column_size=1, .octet_length=1},
+        {.type_id=Bool, .type_name="Bool", .data_type=SQL_BIT, .column_size=1,
+            .case_sensitive=false, .octet_length=1},
         {.type_id=Int8, .type_name="Int8", .data_type=SQL_TINYINT, .column_size=1 + 3,
             .unsigned_attribute=Signed, .num_prec_radix=10, .octet_length=1}, // one char for sign
         {.type_id=UInt8, .type_name="UInt8", .data_type=SQL_TINYINT, .column_size=3,
@@ -687,6 +690,13 @@ struct DataSourceType<DataSourceTypeId::Float64>
     : public SimpleTypeWrapper<double>
 {
     using SimpleTypeWrapper<double>::SimpleTypeWrapper;
+};
+
+template <>
+struct DataSourceType<DataSourceTypeId::Bool>
+    : public SimpleTypeWrapper<std::int8_t>
+{
+    using SimpleTypeWrapper<std::int8_t>::SimpleTypeWrapper;
 };
 
 template <>

--- a/test/src/e2e/test_datatypes.py
+++ b/test/src/e2e/test_datatypes.py
@@ -13,7 +13,6 @@ from util import pyodbc_connection, create_table, rows_as_values, to_base64
 #  Sample error: Attempt to read after eof: while converting '' to UInt8. (ATTEMPT_TO_READ_AFTER_EOF)
 #
 # TODO:
-#  Bool
 #  (U)Int128
 #  (U)Int256
 #  Decimal256
@@ -24,13 +23,10 @@ from util import pyodbc_connection, create_table, rows_as_values, to_base64
 #  LowCardinality
 class TestDataTypes:
     def test_bool(self):
-        """ Bool are currently converted to a string.
-        This should be fixed in the future. The test demonstrates the problem.
-        """
         table_name = "odbc_test_data_types_bool"
         with (pyodbc_connection() as conn,
               create_table(conn, table_name, "b Bool")):
-            values = ['true', 'false'] # strings, but should be `[True, False]`
+            values = [True, False]
             conn.insert(table_name, "(true), (false)")
 
             for value in values:
@@ -38,7 +34,7 @@ class TestDataTypes:
                 assert len(rows) == 1
                 assert rows_as_values(rows) == [value]
                 assert rows[0].cursor_description[0][0] == "b"
-                assert rows[0].cursor_description[0][1] == str # should be `bool`
+                assert rows[0].cursor_description[0][1] == bool
 
             rows = conn.query(f"SELECT * FROM {table_name}")
             assert len(rows) == 2


### PR DESCRIPTION
Bool is returned as a string by the ODBCDriver2 format, so the standard type parsers could not parse `true` and `false` into the expected integer. This fix resolves the issue by explicitly handling `true` and `false` values for Bool columns.

Fixes [#486 Bool columns are represented as strings](https://github.com/ClickHouse/clickhouse-odbc/issues/486)


> [!WARNING]
> This can be a breaking change for users of ODBC wrappers such as PyODBC. These wrappers extract type information automatically, and before this change the driver reported str as the expected type for inserting and reading data. With this change, it now expects bool, and attempting to insert or read a string will fail.
Similarly, from any ODBC client, attempting to read a Bool column as a string using `SQLGetData`, `SQLBindCol`, etc. will return `0` and `1` instead of `true` and `false`, as it did before this change. This makes the driver more consistent with other drivers.