### PR TITLE
Avoid eager local timezone lookup when ClickHouse sends a timezone header

### DIFF
--- a/driver/statement.cpp
+++ b/driver/statement.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 
 static const char exception_code_header_name[] = "X-ClickHouse-Exception-Code";
+static const char timezone_header_name[] = "X-ClickHouse-Timezone";
 
 Statement::Statement(Connection & connection)
     : ChildType(connection)
@@ -29,6 +30,16 @@ Statement::~Statement() {
 
 const TypeInfo & Statement::getTypeInfo(const std::string & type_name, const std::string & type_name_without_parameters) const {
     return getParent().getTypeInfo(type_name, type_name_without_parameters);
+}
+
+std::string Statement::getResponseTimezone(
+    const Poco::Net::HTTPResponse & response,
+    std::string (*get_default_timezone)())
+{
+    if (response.has(timezone_header_name))
+        return response.get(timezone_header_name);
+
+    return get_default_timezone();
 }
 
 void Statement::prepareQuery(const std::string & q) {
@@ -201,9 +212,11 @@ void Statement::requestNextPackOfResultSets(std::unique_ptr<ResultMutator> && mu
         throw std::runtime_error(error_message.str());
     }
 
+    const auto timezone = getResponseTimezone(*response, Poco::Timezone::name);
+
     result_reader = make_result_reader(
         response->get("X-ClickHouse-Format", connection.default_format),
-        response->get("X-ClickHouse-Timezone", Poco::Timezone::name()),
+        timezone,
         *in,
         *connection.session,
         std::move(mutator)

--- a/driver/statement.h
+++ b/driver/statement.h
@@ -91,6 +91,10 @@ public:
 
 public:
     // public only for the unit tests
+    static std::string getResponseTimezone(
+        const Poco::Net::HTTPResponse & response,
+        std::string (*get_default_timezone)());
+
     struct HttpRequestData {
         std::string query;
         std::map<std::string, std::string> params;

--- a/driver/test/CMakeLists.txt
+++ b/driver/test/CMakeLists.txt
@@ -19,6 +19,7 @@ function (declare_odbc_test_targets libname UNICODE)
         connection_string_ut.cpp
         performance_ut.cpp
         statement_parameter_binding_ut.cpp
+        statement_ut.cpp
         type_info_ut.cpp
     )
 

--- a/driver/test/statement_ut.cpp
+++ b/driver/test/statement_ut.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include "driver/statement.h"
+
+namespace {
+
+std::string unexpectedTimezoneFallback() {
+    ADD_FAILURE() << "The local timezone fallback must not be evaluated when the response has a timezone header";
+    return {};
+}
+
+std::string expectedTimezoneFallback() {
+    return "local-timezone";
+}
+
+TEST(Statement, ResponseTimezoneUsesHeaderWithoutFallback) {
+    Poco::Net::HTTPResponse response;
+    response.set("X-ClickHouse-Timezone", "UTC");
+
+    EXPECT_EQ(Statement::getResponseTimezone(response, unexpectedTimezoneFallback), "UTC");
+}
+
+TEST(Statement, ResponseTimezoneUsesEmptyHeaderWithoutFallback) {
+    Poco::Net::HTTPResponse response;
+    response.set("X-ClickHouse-Timezone", "");
+
+    EXPECT_EQ(Statement::getResponseTimezone(response, unexpectedTimezoneFallback), "");
+}
+
+TEST(Statement, ResponseTimezoneUsesFallbackWithoutHeader) {
+    Poco::Net::HTTPResponse response;
+
+    EXPECT_EQ(Statement::getResponseTimezone(response, expectedTimezoneFallback), "local-timezone");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Avoid evaluating `Poco::Timezone::name()` when the ClickHouse response already
contains `X-ClickHouse-Timezone`.

## Root cause

The existing call used `Poco::Timezone::name()` as the default argument to
`response->get()`. C++ evaluates that argument before calling `get()`, even
when the response header is present. On glibc, `Poco::Timezone::name()` calls
`tzset()` and reads `tzname`. Concurrent `localtime_r()` activity can leave
`tzname[0]` null between those operations, causing a crash even though the
driver then uses the server-provided timezone.

## Changes

- Resolve the response timezone through a lazy fallback function, so
  `Poco::Timezone::name()` is called only if the header is absent.
- Add deterministic tests for present nonempty, present empty, and absent
  timezone headers. The present-header tests supply a fallback that fails if it
  is evaluated.

The change preserves the existing absent-header fallback and an explicitly
present empty header.

## Validation

- Oracle Linux 9.8 (glibc 2.34): all 548 ANSI and 548 Unicode unit tests pass.
- The three `Statement.ResponseTimezone*` tests pass in both ANSI and Unicode
  executables.
- Fresh real UnixODBC harness run against ClickHouse 26.6.1.1193:
  - 5-second control: 4,772 queries, 0 conversions, `result=0`;
  - 10-second concurrent `localtime_r()` run: 11,794 queries,
    263,262,925 conversions, `result=0`.
- The unmodified driver was previously reproduced crashing with exit 139 under
  the same concurrent workload; the Docker bundle contains the complete flow.

## Manual reproduction

Attach `clickhouse-odbc-timezone-race-reproducer-v2.zip` from this change. It
contains the Docker build environment, UnixODBC harness, expected baseline
failure, fixed-driver verification, and cleanup commands.