### PR TITLE
Pass pServerCert->hCertStore for hAdditionalStore argument in CertificateChain

### DIFF
--- a/contrib/poco/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/contrib/poco/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -1395,7 +1395,7 @@ void SecureSocketImpl::verifyCertificateChainClient(PCCERT_CONTEXT pServerCert)
 							NULL,
 							_pPeerCertificate,
 							NULL,
-							NULL,
+							pServerCert->hCertStore,
 							&chainPara,
 							0,
 							NULL,


### PR DESCRIPTION
This is just an application of the changes made in https://github.com/pocoproject/poco/pull/3910

Fixes #578 

This is a literal copy from the above mentioned PR and POCO and a simple cherry-pick of that single change.