### PR TITLE
Fix macOS CI broken by Homebrew's master branch removal

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -51,14 +51,13 @@ jobs:
         mkdir -p ${{ github.workspace }}/package
 
     - name: Clone the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: source
         submodules: true
 
     - name: Install dependencies - Common
       run: |
-        cd "$(brew --repo)" && git fetch && git reset --hard origin/master && cd -
         brew remove -f --ignore-dependencies -q libiodbc unixodbc freetds php node composer
         brew install git cmake perl python openssl poco icu4c binutils curl
         pip3 install --break-system-packages --user 'testflows==1.6.56'
@@ -105,8 +104,8 @@ jobs:
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
         -DODBC_PROVIDER=${{ matrix.odbc_provider }} \
-        -DICU_ROOT=/usr/local/opt/icu4c \
-        -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
+        -DICU_ROOT="$(brew --prefix icu4c)" \
+        -DOPENSSL_ROOT_DIR="$(brew --prefix openssl)" \
         -DCH_ODBC_RUNTIME_LINK_STATIC=${{ fromJSON('{"static-runtime": "ON", "dynamic-runtime": "OFF"}')[matrix.runtime_link] }} \
         -DCH_ODBC_PREFER_BUNDLED_THIRD_PARTIES=${{ fromJSON('{"bundled-third-parties": "ON", "system-third-parties": "OFF"}')[matrix.third_parties] }} \
         -DTEST_DSN_LIST="$dsn_string" \


### PR DESCRIPTION
## Problem

Both macOS jobs fail in the first setup step, `Install dependencies - Common`, and have done so since the 2026-09-07 scheduled run ([run 34069115461](https://github.com/ClickHouse/clickhouse-odbc/actions/runs/34069115461)). It also fails on unrelated PRs, e.g. [#583](https://github.com/ClickHouse/clickhouse-odbc/pull/583).

The step began with:

```bash
cd "$(brew --repo)" && git fetch && git reset --hard origin/master && cd -
```

Homebrew renamed its default branch from `master` to `main`. `origin/master` now points at a bootstrap commit whose only purpose is to abort:

```
HEAD is now at 67984c752d Merge pull request #23733 from Homebrew/legacy-master-bootstrap
Error: Homebrew's master branch is no longer supported.
Run `brew update` to migrate to the main branch.
##[error]Process completed with exit code 1.
```

After the reset, every subsequent `brew` command fails.

## Fix

Drop the reset. It was a hack dating back to the 2021 workflow rewrite (2d587a2); the `macos-latest` image already ships a current Homebrew and `brew install` updates as needed. Pointing it at `origin/main` instead would work today but keeps the same brittle construct.

## Additional cleanups in the same workflow

- **`actions/checkout@v2` -> `@v4`** — matches every other workflow in the repo and clears the Node 20 deprecation warnings.
- **`ICU_ROOT` / `OPENSSL_ROOT_DIR` from `brew --prefix`** — these were hardcoded to `/usr/local/opt/...`, the Intel Homebrew prefix. `macos-latest` is arm64 (bottles in the logs are `arm64_tahoe`) with Homebrew in `/opt/homebrew`, and the formulae now resolve to versioned kegs (`icu4c` -> `icu4c@78`, `openssl` -> `openssl@3`), so the configured paths did not exist. This went unnoticed because the build uses bundled third parties and compiles ICU/OpenSSL from `contrib/`.

Both cleanups are behaviour-preserving; the real fix is the removed line.